### PR TITLE
Added feature to display files by backlinks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "notebook-navigator",
-	"version": "1.0.1",
+	"version": "1.0.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "notebook-navigator",
-			"version": "1.0.1",
+			"version": "1.0.5",
 			"license": "GPL-3.0",
 			"dependencies": {
 				"date-fns": "^4.1.0",

--- a/src/components/BacklinkList.tsx
+++ b/src/components/BacklinkList.tsx
@@ -1,0 +1,122 @@
+/*
+ * Notebook Navigator - Plugin for Obsidian
+ * Copyright (c) 2025 Johan Sanneblad
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// src/components/TagList.tsx
+import React, { useMemo } from 'react';
+import { getAllTags } from 'obsidian';
+import { useAppContext } from '../context/AppContext';
+import { buildBacklinkTree, BacklinkTreeNode, getTotalNoteCount, GenericLinkCache } from '../utils/backlinkUtils';
+import { TagTreeItem } from './TagTreeItem';
+import { parseExcludedProperties, shouldExcludeFile } from '../utils/fileFilters';
+
+/**
+ * Component that displays all Backlinks in the vault as a hierarchical tree.
+ * Backlinks are organized by their path structure (e.g., inbox/processing).
+ */
+export function BacklinkList() {
+    const { app, appState, dispatch, plugin, refreshCounter, isMobile } = useAppContext();
+
+    // Don't render if backlinks are disabled in settings
+    if (!plugin.settings.showBacklinks) {
+        return null;
+    }
+
+    // Build the tag tree from all vault files
+    const tagTree = useMemo(() => {
+        const excludedProperties = parseExcludedProperties(plugin.settings.excludedFiles);
+        const allFiles = app.vault.getMarkdownFiles().filter(file => {
+            return !excludedProperties.length || !shouldExcludeFile(file, excludedProperties, app);
+        });
+        return buildBacklinkTree(allFiles, plugin.settings.backlinksFolderPath, app);
+    }, [app.vault, app.metadataCache, plugin.settings.excludedFiles, refreshCounter]);
+
+    // Recursive render function for tag nodes
+    const renderBacklinkNode = (tagNode: BacklinkTreeNode, level: number = 0): React.ReactNode => {
+        const isExpanded = appState.expandedTags.has(tagNode.path);
+        const isSelected = appState.selectionType === 'tag' && appState.selectedTag === tagNode.path;
+        const fileCount = getTotalNoteCount(tagNode);
+
+        return (
+            <React.Fragment key={tagNode.path}>
+                <TagTreeItem
+                    tagNode={tagNode}
+                    level={level}
+                    isExpanded={isExpanded}
+                    isSelected={isSelected}
+                    fileCount={fileCount}
+                    showFileCount={plugin.settings.showFolderFileCount}
+                    onClick={() => {
+                        dispatch({ type: 'SET_SELECTED_BACKLINK', backlink: tagNode.path });
+                        if (isMobile) {
+                            dispatch({ type: 'SET_MOBILE_VIEW', view: 'files' });
+                        }
+                    }}
+                    onToggle={() => dispatch({ type: 'TOGGLE_TAG_EXPANDED', tagPath: tagNode.path })}
+                />
+                <div className={`nn-tag-children ${isExpanded ? 'nn-expanded' : ''}`}>
+                    <div className="nn-tag-children-inner">
+                        {isExpanded && Array.from(tagNode.children.values())
+                            .sort((a, b) => a.name.localeCompare(b.name))
+                            .map(child => renderBacklinkNode(child, level + 1))}
+                    </div>
+                </div>
+            </React.Fragment>
+        );
+    };
+
+    // Count untagged files only when needed
+    const untaggedCount = useMemo(() => {
+        if (!plugin.settings.showUntagged) {
+            return 0;
+        }
+        
+        const excludedProperties = parseExcludedProperties(plugin.settings.excludedFiles);
+        return app.vault.getMarkdownFiles().filter(file => {
+            if (excludedProperties.length && shouldExcludeFile(file, excludedProperties, app) || file.path.startsWith(plugin.settings.backlinksFolderPath)) {
+                return false;
+            }
+            const cache = app.metadataCache.getFileCache(file);
+            let links: GenericLinkCache[] | undefined = cache?.links || [];
+            links = links.concat(cache?.frontmatterLinks || []);
+            const procLinks = links?.filter(link => {
+                const linkFile = app.metadataCache.getFirstLinkpathDest(link.link, file.path);
+                if (!linkFile) return false;
+                if (!linkFile.path.startsWith(plugin.settings.backlinksFolderPath)) return false;
+                return true;
+            });
+            return !procLinks || procLinks.length === 0;
+        }).length;
+    }, [plugin.settings.showUntagged, app.vault, app.metadataCache, plugin.settings.excludedFiles, refreshCounter]);
+
+    // Get root nodes and sort them
+    const rootNodes = Array.from(tagTree.values()).sort((a, b) => a.name.localeCompare(b.name));
+
+    // Don't render if there are no tags and no untagged files
+    if (rootNodes.length === 0 && untaggedCount === 0) {
+        return null;
+    }
+
+    return (
+        <div className="nn-tag-list-container">
+            <div className="nn-section-header">Tag Links</div>
+            <div className="nn-tag-list">
+                {rootNodes.map(node => renderBacklinkNode(node, 0))}
+            </div>
+        </div>
+    );
+}

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -117,7 +117,7 @@ export function FileList() {
             // Special case for untagged files
             if (selectedBacklink === UNTAGGED_TAG_ID) {
                 allFiles = allMarkdownFiles.filter(file => {
-                    if (file.path.startsWith(plugin.settings.backlinksFolderPath)) {
+                    if (plugin.settings.backlinksFolderPath && file.path.startsWith(plugin.settings.backlinksFolderPath)) {
                         return false;
                     }
                     const cache = app.metadataCache.getFileCache(file);

--- a/src/components/NotebookNavigatorComponent.tsx
+++ b/src/components/NotebookNavigatorComponent.tsx
@@ -22,6 +22,7 @@ import { TFile, WorkspaceLeaf } from 'obsidian';
 import { PaneHeader } from './PaneHeader';
 import { FolderTree } from './FolderTree';
 import { TagList } from './TagList';
+import { BacklinkList } from './BacklinkList';
 import { FileList } from './FileList';
 import { useAppContext } from '../context/AppContext';
 import { useKeyboardNavigation } from '../hooks/useKeyboardNavigation';
@@ -130,6 +131,7 @@ export const NotebookNavigatorComponent = forwardRef<NotebookNavigatorHandle>((_
                 <div className="nn-left-pane-scroller">
                     <FolderTree />
                     <TagList />
+                    <BacklinkList />
                 </div>
             </div>
             {!isMobile && <div className="nn-resize-handle" {...resizeHandleProps} />}

--- a/src/components/PaneHeader.tsx
+++ b/src/components/PaneHeader.tsx
@@ -98,6 +98,8 @@ export function PaneHeader({ type }: PaneHeaderProps) {
             headerTitle = appState.selectedFolder.path === '/' ? 'Vault' : appState.selectedFolder.name;
         } else if (appState.selectionType === 'tag' && appState.selectedTag) {
             headerTitle = appState.selectedTag === '__untagged__' ? 'Untagged' : appState.selectedTag;
+        } else if (appState.selectionType === 'backlink' && appState.selectedBacklink) {
+            headerTitle = appState.selectedBacklink === '__untagged__' ? 'Untagged' : appState.selectedBacklink;
         }
         
         // For file pane header on mobile

--- a/src/components/TagTreeItem.tsx
+++ b/src/components/TagTreeItem.tsx
@@ -40,6 +40,8 @@ interface TagTreeItemProps {
     fileCount: number;
     /** Whether to show file counts */
     showFileCount: boolean;
+    /** Whether this is a backlink item */
+    backlink?: boolean;
 }
 
 /**
@@ -54,7 +56,8 @@ export function TagTreeItem({
     onToggle, 
     onClick, 
     fileCount,
-    showFileCount
+    showFileCount,
+    backlink=false
 }: TagTreeItemProps) {
     const chevronRef = React.useRef<HTMLDivElement>(null);
     const hasChildren = tagNode.children.size > 0;
@@ -68,7 +71,7 @@ export function TagTreeItem({
 
     return (
         <div 
-            className={`nn-tag-item ${isSelected ? 'nn-selected' : ''}`} 
+            className={`nn-tag-item ${isSelected ? 'nn-selected' : ''} ${backlink ? 'nn-backlink-item' : ''}`} 
             data-tag={tagNode.path}
             style={{ paddingLeft: `${level * 20}px` }}
         >

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -28,13 +28,15 @@ import { isTFolder, isTFile } from '../utils/typeGuards';
  */
 export interface AppState {
     /** Type of selection - either folder or tag */
-    selectionType: 'folder' | 'tag';
+    selectionType: 'folder' | 'tag' | 'backlink';
     /** Currently selected folder in the folder tree */
     selectedFolder: TFolder | null;
     /** Currently selected tag */
     selectedTag: string | null;
     /** Currently selected file in the file list */
     selectedFile: TFile | null;
+    /** Currently selected backlink */
+    selectedBacklink: string | null;
     /** Set of folder paths that are currently expanded in the tree */
     expandedFolders: Set<string>;
     /** Set of tag paths that are currently expanded in the tree */
@@ -54,6 +56,7 @@ export interface AppState {
 export type AppAction = 
     | { type: 'SET_SELECTED_FOLDER'; folder: TFolder | null }
     | { type: 'SET_SELECTED_TAG'; tag: string | null }
+    | { type: 'SET_SELECTED_BACKLINK'; backlink: string | null }
     | { type: 'SET_SELECTED_FILE'; file: TFile | null }
     | { type: 'SET_EXPANDED_FOLDERS'; folders: Set<string> }
     | { type: 'TOGGLE_FOLDER_EXPANDED'; folderPath: string }
@@ -210,12 +213,17 @@ function appReducer(state: AppState, action: AppAction, app: App): AppState {
     switch (action.type) {
         case 'SET_SELECTED_FOLDER': {
             // Update the selected folder and clear tag selection
-            return { ...state, selectionType: 'folder', selectedFolder: action.folder, selectedTag: null };
+            return { ...state, selectionType: 'folder', selectedFolder: action.folder, selectedBacklink: null, selectedTag: null };
         }
         
         case 'SET_SELECTED_TAG': {
             // Update the selected tag and clear folder selection
-            return { ...state, selectionType: 'tag', selectedTag: action.tag, selectedFolder: null };
+            return { ...state, selectionType: 'tag', selectedTag: action.tag, selectedBacklink: null, selectedFolder: null };
+        }
+
+        case 'SET_SELECTED_BACKLINK': {
+            // Update the selected backlink and clear folder selection
+            return { ...state, selectionType: 'backlink', selectedTag: null, selectedBacklink: action.backlink, selectedFolder: null };
         }
         
         case 'SET_SELECTED_FILE': {

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,6 +49,7 @@ export default class NotebookNavigatorPlugin extends Plugin {
     keys: LocalStorageKeys = {
         expandedFoldersKey: 'notebook-navigator-expanded-folders',
         expandedTagsKey: 'notebook-navigator-expanded-tags',
+        expandedBacklinksKey: 'notebook-navigator-expanded-backlinks',
         selectedFolderKey: 'notebook-navigator-selected-folder',
         selectedFileKey: 'notebook-navigator-selected-file',
         leftPaneWidthKey: 'notebook-navigator-left-pane-width'

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -48,6 +48,9 @@ export interface NotebookNavigatorSettings {
     // Tag display
     showTags: boolean;
     showUntagged: boolean;
+    // Backlink display
+    showBacklinks: boolean;
+    backlinksFolderPath: string;
     // Appearance
     dateFormat: string;
     // Advanced
@@ -84,6 +87,9 @@ export const DEFAULT_SETTINGS: NotebookNavigatorSettings = {
     // Tag display
     showTags: true,
     showUntagged: false,
+    // Backlink display
+    showBacklinks: true,
+    backlinksFolderPath: "",
     // Appearance
     dateFormat: 'MMM d, yyyy',
     // Advanced
@@ -138,7 +144,7 @@ export class NotebookNavigatorSettingTab extends PluginSettingTab {
         getValue: () => string,
         setValue: (value: string) => void,
         refreshView: boolean = true,
-        validator?: (value: string) => boolean
+        validator?: (value: string) => boolean,
     ): Setting {
         return new Setting(container)
             .setName(name)
@@ -394,7 +400,32 @@ export class NotebookNavigatorSettingTab extends PluginSettingTab {
                     await this.saveAndRefresh();
                 }));
 
-        // Section 5: Appearance
+        // Section 5: Backlink display
+        new Setting(containerEl)
+            .setName('Tag Link display')
+            .setHeading();
+
+        const showBacklinksSetting = new Setting(containerEl)
+            .setName('Show tag links')
+            .setDesc('Display tag links section below folders in the navigator.')
+            .addToggle(toggle => toggle
+                .setValue(this.plugin.settings.showBacklinks)
+                .onChange(async (value) => {
+                    this.plugin.settings.showBacklinks = value;
+                    await this.saveAndRefresh();
+                }));
+
+        this.createDebouncedTextSetting(
+            containerEl,
+            'Tag links folder path',
+            'Root folder for tag links (to use if you have a tags folder and want to exclude all other backlinks). Leave empty to use the whole vault.',
+            '',
+            () => this.plugin.settings.backlinksFolderPath,
+            (value) => { this.plugin.settings.backlinksFolderPath = value || ''; },
+        );
+
+
+        // Section 6: Appearance
         new Setting(containerEl)
             .setName('Appearance')
             .setHeading();
@@ -413,7 +444,7 @@ export class NotebookNavigatorSettingTab extends PluginSettingTab {
                 new Notice('Common formats:\nMMM d, yyyy = May 25, 2022\ndd/MM/yyyy = 25/05/2022\nyyyy-MM-dd = 2022-05-25\n\nTokens:\nyyyy/yy = year\nMMMM/MMM/MM = month\ndd/d = day\nEEEE/EEE = weekday', 10000);
             }));
 
-        // Section 6: Advanced
+        // Section 7: Advanced
         new Setting(containerEl)
             .setName('Advanced')
             .setHeading();

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -469,6 +469,7 @@ export class NotebookNavigatorSettingTab extends PluginSettingTab {
                     // Clear all localStorage keys
                     localStorage.removeItem(this.plugin.keys.expandedFoldersKey);
                     localStorage.removeItem(this.plugin.keys.expandedTagsKey);
+                    localStorage.removeItem(this.plugin.keys.expandedBacklinksKey);
                     localStorage.removeItem(this.plugin.keys.selectedFolderKey);
                     localStorage.removeItem(this.plugin.keys.selectedFileKey);
                     localStorage.removeItem(this.plugin.keys.leftPaneWidthKey);

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,7 @@ export type FocusedPane = 'folders' | 'files';
 export interface LocalStorageKeys {
     expandedFoldersKey: string;
     expandedTagsKey: string;
+    expandedBacklinksKey: string;
     selectedFolderKey: string;
     selectedFileKey: string;
     leftPaneWidthKey: string;

--- a/src/utils/backlinkUtils.ts
+++ b/src/utils/backlinkUtils.ts
@@ -1,0 +1,217 @@
+/*
+ * Notebook Navigator - Plugin for Obsidian
+ * Copyright (c) 2025 Johan Sanneblad
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { TFile, App, getAllTags, Plugin } from 'obsidian';
+import { cache } from 'react';
+
+
+/**
+ * Interface that covers the necessary parts of LinkCache and FrontmatterLinkCache
+ * to filter backlinks correctly.
+ */
+export interface GenericLinkCache {
+    displayText?: string; // The text displayed for the link
+    link: string; // The link path
+    original: string; // The original link text
+    key?: string; // Unique key for the link (Frontmatter only)
+    position?: {
+        start: { line: number; col: number }; // Start position of the link in the file
+        end: { line: number; col: number }; // End position of the link in the file
+    }; // Position in the file (optional)
+}
+
+/**
+ * Represents a node in the hierarchical backlink tree.
+ * Each node contains information about a backlink and its nested children.
+ */
+export interface BacklinkTreeNode {
+    /** The name of this part of the tag (e.g., "processing" for "#inbox/processing") */
+    name: string;
+    /** The full path of the backlink (e.g., "inbox/processing") */
+    path: string;
+    /** Map of child backlink nodes, keyed by their name */
+    children: Map<string, BacklinkTreeNode>;
+    /** Set of file paths that have this exact backlink */
+    notesWithTag: Set<string>;
+}
+
+/**
+ * Builds a hierarchical tree structure from flat backlinks
+ * Backlinks like "inbox/processing" will create nested nodes
+*  if backlinksFolderPath is set
+ * 
+ * @param allFiles - Array of markdown files to process
+ * @param folderPath - Path of the folder, if applicable (otherwise empty string) which contains tag backlink files
+ * @param app - Obsidian app instance for metadata access
+ * @returns Map of root-level backlink nodes
+ */
+export function buildBacklinkTree(allFiles: TFile[], folderPath: string, app: App): Map<string, BacklinkTreeNode> {
+    const root = new Map<string, BacklinkTreeNode>();
+    
+    // Early return for empty file list
+    if (!allFiles || allFiles.length === 0) {
+        return root;
+    }
+    
+    const allBacklinksCache = new Map<string, Set<string>>();
+
+    // First pass: collect all backlinks and their associated files
+    for (const file of allFiles) {
+        const fileCache = app.metadataCache.getFileCache(file);
+        if (!fileCache) continue;
+
+        const links = (fileCache.links as GenericLinkCache[] | undefined)?.concat(fileCache.frontmatterLinks || []);
+        if (!links || links.length === 0) continue;
+        for (const link of links) {
+            // Get file from link
+            const linkFile = app.metadataCache.getFirstLinkpathDest(link.link, file.path);
+            if (!linkFile) continue;
+            if (!linkFile.path.startsWith(folderPath)) continue;
+            let backlinkPath;
+            if (folderPath) {
+                backlinkPath = linkFile.path.replace(folderPath + '/', '');
+            } else {
+                backlinkPath = linkFile.path; // Use full path if no folderPath is set
+            }
+            // Remove any extension if present
+            backlinkPath = backlinkPath.replace(/\.(md|canvas|base)$/, '');
+            if (!allBacklinksCache.has(backlinkPath)) {
+                allBacklinksCache.set(backlinkPath, new Set());
+            }
+            allBacklinksCache.get(backlinkPath)!.add(file.path);
+        }
+    }
+
+    // Second pass: build the tree structure
+    allBacklinksCache.forEach((notes, backlink) => {
+        // Remove any remaining / prefix and split by /
+        if (backlink.startsWith('/')) {
+            backlink = backlink.substring(1);
+        }
+        const parts = backlink.split('/');
+        let currentLevel = root;
+
+        parts.forEach((part, index) => {
+            // Rebuild the full path up to this point
+            const currentPath = parts.slice(0, index + 1).join('/');
+
+            if (!currentLevel.has(part)) {
+                currentLevel.set(part, {
+                    name: part,
+                    path: currentPath,
+                    children: new Map(),
+                    notesWithTag: new Set(),
+                });
+            }
+
+            const node = currentLevel.get(part)!;
+
+            // If this is the last part, it's the actual tag with notes
+            if (index === parts.length - 1) {
+                node.notesWithTag = notes;
+            }
+
+            currentLevel = node.children;
+        });
+    });
+
+    return root;
+}
+
+// Cache for total note counts to avoid recalculation
+const noteCountCache = new WeakMap<BacklinkTreeNode, number>();
+
+/**
+ * Gets the total count of notes for a backlink node including all its children.
+ * This is useful for showing aggregate counts in parent backlink.
+ * Uses memoization to improve performance.
+ * 
+ * @param node - The backlink node to count
+ * @returns Total number of notes with this backlink or any child backlink
+ */
+export function getTotalNoteCount(node: BacklinkTreeNode): number {
+    // Check cache first
+    const cached = noteCountCache.get(node);
+    if (cached !== undefined) {
+        return cached;
+    }
+    
+    let count = node.notesWithTag.size;
+    
+    for (const child of node.children.values()) {
+        count += getTotalNoteCount(child);
+    }
+    
+    // Cache the result
+    noteCountCache.set(node, count);
+    
+    return count;
+}
+
+/**
+ * Collects all backlink paths from a node and its descendants.
+ * Used when filtering files by a parent tag.
+ * 
+ * @param node - The root node to start from
+ * @param paths - Set to collect paths into (optional)
+ * @returns Set of all backlink paths in this subtree
+ */
+export function collectAllBacklinkPaths(node: BacklinkTreeNode, paths: Set<string> = new Set()): Set<string> {
+    paths.add(node.path);
+    
+    for (const child of node.children.values()) {
+        collectAllBacklinkPaths(child, paths);
+    }
+    
+    return paths;
+}
+
+/**
+ * Finds a backlink node by its path in the tree.
+ * 
+ * @param path - The backlink path to find (e.g., "inbox/processing")
+ * @param tree - The root tree to search in
+ * @returns The tag node if found, null otherwise
+ */
+export function findBacklinkNode(path: string, tree: Map<string, BacklinkTreeNode>): BacklinkTreeNode | null {
+    // Validate input
+    if (!path || path.length <= 1) {
+        return null;
+    }
+
+    // Remove leading slash if present
+    if (path.startsWith('/')) {
+        path = path.substring(1);
+    } 
+    
+    const parts = path.split('/').filter(part => part.length > 0);
+    if (parts.length === 0) {
+        return null;
+    }
+    
+    let currentLevel = tree;
+    let currentNode: BacklinkTreeNode | undefined;
+
+    for (const part of parts) {
+        currentNode = currentLevel.get(part);
+        if (!currentNode) return null;
+        currentLevel = currentNode.children;
+    }
+
+    return currentNode || null;
+}


### PR DESCRIPTION
While the tags sorting is great, I personally don't use tags. What I instead use is a system of backlinks where I link to certain files. This pull request adds a hierarchical view of all backlinks, in the same style of the tags view. It also adds an option to set a root folder for backlink tags (for example, I put all my tag markdown files in a folder called "01 Tags") which removes extraneous backlinks.

Some things to consider before merging:

- [ ] Do we want to use a different symbol than the "#" used in tags
- [ ] Make sure keyboard shortcuts work — the animation seems to not work the same with the backlinks keyboard shortcuts and I'm not sure why
- [ ] Make sure I haven't forgotten to implement some feature that works for the normal tabs panel for the backlinks tag panel — I've tried to search the codebase, but I'm not all that familiar.