### PR TITLE
Hide the separator lines above and below the selected file in the list

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -727,6 +727,17 @@ button.nn-icon-button {
     border-radius: var(--radius-m);
 }
 
+/* Hide the separators above and below the selected file */
+/* Remove separator below selected item */
+.nn-file-item.nn-selected::after {
+    display: none;
+}
+
+/* Remove separator above selected item */
+.nn-file-item:has(+ .nn-file-item.nn-selected)::after {
+    display: none;
+}
+
 /* Dark mode selected file pseudo-element */
 .theme-dark .nn-file-item.nn-selected .nn-file-content::before {
     filter: brightness(0.5);


### PR DESCRIPTION
I actually worked on a super similar plugin about a year ago (even called it Note Navigator! 😆), but wound up abandoning it due to performance issues, so I'm so glad you've done this!!

In my attempt, I tried to deal with having the little 1px separator lines butting up against the top and bottom of the selected file in the list. This PR hides those lines using pseudo-elements, which is the best approach I could find to mimicking the macOS-style selected behavior where those separators disappear around the active item.