### PR TITLE
alphanumeric sort by number, not digit

### DIFF
--- a/src/hooks/useNavigationPaneData.ts
+++ b/src/hooks/useNavigationPaneData.ts
@@ -45,6 +45,7 @@ import { shouldDisplayFile } from '../utils/fileTypeUtils';
 import { leadingEdgeDebounce } from '../utils/leadingEdgeDebounce';
 import { getTotalNoteCount, excludeFromTagTree } from '../utils/tagTree';
 import { flattenFolderTree, flattenTagTree } from '../utils/treeFlattener';
+import { alphanumericCompare } from 'src/utils/sortUtils'
 
 /**
  * Parameters for the useNavigationPaneData hook
@@ -479,7 +480,7 @@ export function useNavigationPaneData({ settings, isVisible }: UseNavigationPane
             } else {
                 folders = root.children
                     .filter((child): child is TFolder => child instanceof TFolder)
-                    .sort((a, b) => a.name.localeCompare(b.name));
+                    .sort((a, b) => alphanumericCompare(a.name, b.name));
             }
 
             setRootFolders(folders);

--- a/src/modals/FolderSuggestModal.ts
+++ b/src/modals/FolderSuggestModal.ts
@@ -19,6 +19,7 @@
 import { App, TFolder } from 'obsidian';
 import { strings } from '../i18n';
 import { BaseSuggestModal } from './BaseSuggestModal';
+import { alphanumericCompare } from 'src/utils/sortUtils'
 
 /**
  * Modal for selecting a folder to move files to
@@ -73,7 +74,7 @@ export class FolderSuggestModal extends BaseSuggestModal<TFolder> {
         collectFolders(this.app.vault.getRoot());
 
         // Sort folders by path for consistent ordering
-        folders.sort((a, b) => a.path.localeCompare(b.path));
+        folders.sort((a, b) => alphanumericCompare(a.path, b.path));
 
         return folders;
     }

--- a/src/modals/TagSuggestModal.ts
+++ b/src/modals/TagSuggestModal.ts
@@ -22,6 +22,7 @@ import { TagTreeNode } from '../types/storage';
 import { getTotalNoteCount } from '../utils/tagTree';
 import { BaseSuggestModal } from './BaseSuggestModal';
 import NotebookNavigatorPlugin from '../main';
+import { alphanumericCompare } from 'src/utils/sortUtils'
 
 /**
  * Modal for selecting a tag to navigate to
@@ -169,7 +170,7 @@ export class TagSuggestModal extends BaseSuggestModal<TagTreeNode> {
             // Keep untagged at the top
             if (a.path === '__untagged__') return -1;
             if (b.path === '__untagged__') return 1;
-            return a.path.localeCompare(b.path);
+            return alphanumericCompare(a.path, b.path);
         });
 
         return tags;

--- a/src/utils/deleteOperations.ts
+++ b/src/utils/deleteOperations.ts
@@ -23,6 +23,7 @@ import { TagTreeService } from '../services/TagTreeService';
 import { NotebookNavigatorSettings } from '../settings';
 import { ItemType } from '../types';
 import { getFilesForFolder, getFilesForTag } from './fileFinder';
+import { alphanumericCompare } from './sortUtils'
 
 interface BaseDeleteOperationsContext {
     app: App;
@@ -109,7 +110,7 @@ export async function deleteSelectedFolder({
     if (parentFolder) {
         const siblings = parentFolder.children
             .filter((child): child is TFolder => child instanceof TFolder)
-            .sort((a, b) => a.name.localeCompare(b.name));
+            .sort((a, b) => alphanumericCompare(a.name, b.name));
 
         const currentIndex = siblings.findIndex(f => f.path === folderToDelete.path);
 
@@ -131,7 +132,7 @@ export async function deleteSelectedFolder({
         const rootFolder = app.vault.getRoot();
         const rootFolders = rootFolder.children
             .filter((child): child is TFolder => child instanceof TFolder && child.path !== folderToDelete.path)
-            .sort((a, b) => a.name.localeCompare(b.name));
+            .sort((a, b) => alphanumericCompare(a.name, b.name));
 
         if (rootFolders.length > 0) {
             nextFolderToSelect = rootFolders[0];

--- a/src/utils/sortUtils.ts
+++ b/src/utils/sortUtils.ts
@@ -66,6 +66,8 @@ export function sortFiles(
         return type === 'created' ? getCreatedTime(file) : getModifiedTime(file);
     };
 
+    const collator = new Intl.Collator(undefined, { numeric: true });
+
     switch (sortOption) {
         case 'modified-desc':
             files.sort((a, b) => getTimestamp(b, 'modified') - getTimestamp(a, 'modified'));
@@ -80,10 +82,10 @@ export function sortFiles(
             files.sort((a, b) => getTimestamp(a, 'created') - getTimestamp(b, 'created'));
             break;
         case 'title-asc':
-            files.sort((a, b) => a.basename.localeCompare(b.basename));
+            files.sort((a, b) => collator.compare(a.basename, b.basename));
             break;
         case 'title-desc':
-            files.sort((a, b) => b.basename.localeCompare(a.basename));
+            files.sort((a, b) => collator.compare(b.basename, a.basename));
             break;
     }
 }

--- a/src/utils/sortUtils.ts
+++ b/src/utils/sortUtils.ts
@@ -19,6 +19,7 @@
 import { TFile, TFolder } from 'obsidian';
 import type { SortOption, NotebookNavigatorSettings } from '../settings';
 import { NavigationItemType, ItemType } from '../types';
+import { getCurrentLanguage } from 'src/i18n'
 
 /**
  * Available sort options in order they appear in menus
@@ -97,10 +98,10 @@ export function sortFiles(
  * @param a - First string in compare operation
  * @param b - Second string in compare operation
  */
-export function alphanumericCompare(a: string, b: string, locales?: Intl.LocalesArgument) {
-    const collator = new Intl.Collator(locales, { numeric: true });
+export function alphanumericCompare(a: string, b: string) {
     return collator.compare(a, b)
 }
+const collator = new Intl.Collator(getCurrentLanguage(), { numeric: true });
 
 /**
  * Gets the sort icon name based on sort option

--- a/src/utils/sortUtils.ts
+++ b/src/utils/sortUtils.ts
@@ -66,8 +66,6 @@ export function sortFiles(
         return type === 'created' ? getCreatedTime(file) : getModifiedTime(file);
     };
 
-    const collator = new Intl.Collator(undefined, { numeric: true });
-
     switch (sortOption) {
         case 'modified-desc':
             files.sort((a, b) => getTimestamp(b, 'modified') - getTimestamp(a, 'modified'));
@@ -82,12 +80,26 @@ export function sortFiles(
             files.sort((a, b) => getTimestamp(a, 'created') - getTimestamp(b, 'created'));
             break;
         case 'title-asc':
-            files.sort((a, b) => collator.compare(a.basename, b.basename));
+            files.sort((a, b) => alphanumericCompare(a.basename, b.basename));
             break;
         case 'title-desc':
-            files.sort((a, b) => collator.compare(b.basename, a.basename));
+            files.sort((a, b) => alphanumericCompare(b.basename, a.basename));
             break;
     }
+}
+
+/**
+ * Determines whether two strings are equivalent in the current locale.
+ * Orders numbers in numerical order, not alphanumeric order
+ * For example:
+ * Alphanumeric order: 1, 10, 11, 2, 3
+ * Numeric order: 1, 2, 3, 10, 11
+ * @param a - First string in compare operation
+ * @param b - Second string in compare operation
+ */
+export function alphanumericCompare(a: string, b: string, locales?: Intl.LocalesArgument) {
+    const collator = new Intl.Collator(locales, { numeric: true });
+    return collator.compare(a, b)
 }
 
 /**

--- a/src/utils/treeFlattener.ts
+++ b/src/utils/treeFlattener.ts
@@ -23,6 +23,7 @@ import { TagTreeNode } from '../types/storage';
 import type { FolderTreeItem, TagTreeItem } from '../types/virtualization';
 import { isFolderInExcludedFolder } from './fileFilters';
 import { matchesAnyPrefix } from './tagPrefixMatcher';
+import { alphanumericCompare } from './sortUtils'
 
 /**
  * Flattens a folder tree into a linear array for virtualization.
@@ -77,7 +78,7 @@ export function flattenFolderTree(
             // Get the current language from Obsidian to sort correctly for that locale.
             const locale = getCurrentLanguage();
             // Sort the child folders alphabetically using the detected locale.
-            childFolders.sort((a, b) => a.name.localeCompare(b.name, locale));
+            childFolders.sort((a, b) => alphanumericCompare(a.name, b.name, locale));
 
             if (childFolders.length > 0) {
                 // Create a new set with the current path added
@@ -113,7 +114,7 @@ export function flattenTagTree(
     const items: TagTreeItem[] = [];
 
     // Sort tags alphabetically
-    const sortedNodes = tagNodes.slice().sort((a, b) => a.name.localeCompare(b.name));
+    const sortedNodes = tagNodes.slice().sort((a, b) => alphanumericCompare(a.name, b.name));
 
     function addNode(node: TagTreeNode, currentLevel: number) {
         const item: TagTreeItem = {
@@ -134,7 +135,7 @@ export function flattenTagTree(
 
         // Add children if expanded and has children
         if (expandedTags.has(node.path) && node.children && node.children.size > 0) {
-            const sortedChildren = Array.from(node.children.values()).sort((a, b) => a.name.localeCompare(b.name));
+            const sortedChildren = Array.from(node.children.values()).sort((a, b) => alphanumericCompare(a.name, b.name));
 
             sortedChildren.forEach(child => addNode(child, currentLevel + 1));
         }

--- a/src/utils/treeFlattener.ts
+++ b/src/utils/treeFlattener.ts
@@ -17,7 +17,6 @@
  */
 
 import { TFolder } from 'obsidian';
-import { getCurrentLanguage } from '../i18n';
 import { NavigationPaneItemType } from '../types';
 import { TagTreeNode } from '../types/storage';
 import type { FolderTreeItem, TagTreeItem } from '../types/virtualization';
@@ -75,10 +74,8 @@ export function flattenFolderTree(
         if (expandedFolders.has(folder.path) && folder.children && folder.children.length > 0) {
             const childFolders = folder.children.filter((child): child is TFolder => child instanceof TFolder);
 
-            // Get the current language from Obsidian to sort correctly for that locale.
-            const locale = getCurrentLanguage();
             // Sort the child folders alphabetically using the detected locale.
-            childFolders.sort((a, b) => alphanumericCompare(a.name, b.name, locale));
+            childFolders.sort((a, b) => alphanumericCompare(a.name, b.name));
 
             if (childFolders.length > 0) {
                 // Create a new set with the current path added


### PR DESCRIPTION
Partial solution to #164

Ascending:

<img width="537" height="359" alt="image" src="https://github.com/user-attachments/assets/75fa394c-caeb-418d-9284-9caba2c9b4d8" />

Descending:

<img width="540" height="360" alt="image" src="https://github.com/user-attachments/assets/70c1f403-1bcd-4f17-8258-4b21efdd9b10" />

I swapped String.prototype.localeCompare for Intl.Collator.prototype.compare because localeCompare doesn't support the options argument on Android WebView, but otherwise they're essentially the same function.