### PR TITLE
[FR] Add Transparency Toggles

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3955,6 +3955,48 @@ body.nn-resizing {
     color: var(--text-error);
 }
 
+/* ========================================================================
+   Transparency Toggles
+   ======================================================================== */
+
+/* Navigation pane transparency - applied when toggle is enabled */
+body.nn-navigation-pane-transparent .notebook-navigator {
+    background-color: transparent !important;
+}
+
+body.nn-navigation-pane-transparent .nn-navigation-pane {
+    background-color: transparent !important;
+}
+
+body.nn-navigation-pane-transparent .nn-navigation-pane .nn-pane-header {
+    background-color: transparent !important;
+}
+
+body.nn-navigation-pane-transparent .nn-navigation-pane-scroller {
+    background-color: transparent !important;
+}
+
+/* List pane transparency - applied when toggle is enabled */
+body.nn-list-pane-transparent .notebook-navigator {
+    background-color: transparent !important;
+}
+
+body.nn-list-pane-transparent .nn-list-pane {
+    background-color: transparent !important;
+}
+
+body.nn-list-pane-transparent .nn-list-pane .nn-pane-header {
+    background-color: transparent !important;
+}
+
+body.nn-list-pane-transparent .nn-list-pane-scroller {
+    background-color: transparent !important;
+}
+
+body.nn-list-pane-transparent .nn-list-title-area {
+    background-color: transparent !important;
+}
+
 /* @settings
 
 name: Notebook Navigator
@@ -3977,6 +4019,12 @@ settings:
         format: hex
         default-light: '#'
         default-dark: '#'
+    -
+    -
+        id: nn-navigation-pane-transparent
+        title: Navigation pane transparency
+        description: Make the left navigation pane transparent (removes background).
+        type: class-toggle
     -
     -
         id: nn-nav-pane-items-heading
@@ -4251,6 +4299,13 @@ settings:
         format: hex
         default-light: '#'
         default-dark: '#'
+    -
+    -
+        id: nn-list-pane-transparent
+        title: List pane transparency
+        description: Make the right list pane transparent (removes background).
+        type: class-toggle
+    -
     -
         id: nn-theme-list-search-active-bg
         title: Search field active background


### PR DESCRIPTION
Resolves #386 

This PR introduces 2 new Style Settings toggles to enable transparency of the Navigation and List panes. 

### Style Settings Preview:

Navigation pane transparency
<img height="290" alt="Screenshot 2025-10-14 at 10 14 24 AM" src="https://github.com/user-attachments/assets/10e17ca7-cfed-46c8-ae1e-9a04a4187da2" />

List pane transparency
<img height="290" alt="Screenshot 2025-10-14 at 10 14 35 AM" src="https://github.com/user-attachments/assets/47db49d1-4373-4a06-8226-48ecb5029300" />

## Appearance Preview: 

Both Toggled:

<img height="600" alt="Screenshot 2025-10-14 at 10 17 29 AM" src="https://github.com/user-attachments/assets/0aba3f61-c4bc-4348-b0c5-c57197e36bf1" />

Only list toggled:

<img height="600" alt="Screenshot 2025-10-14 at 10 18 00 AM" src="https://github.com/user-attachments/assets/2017f447-50a5-460a-8c7b-c167a325fd5f" />

Only navigation toggled:

<img height="600" alt="Screenshot 2025-10-14 at 10 18 33 AM" src="https://github.com/user-attachments/assets/6adf0d06-45ee-4fdb-805f-127fe7e451e6" />

Neither toggled (default):

<img height="600" alt="Screenshot 2025-10-14 at 10 18 59 AM" src="https://github.com/user-attachments/assets/f8782107-08d3-4959-a05a-80376f0cd4b9" />



Desktop Wallpaper for reference:
<img height="300" alt="Screenshot 2025-10-14 at 10 15 32 AM" src="https://github.com/user-attachments/assets/d3d06dd9-6647-4fe9-abfb-bd4ea0d5e518" />
