### PR TITLE
feat: add standard Obsidian CSS class to tab buttons

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -327,6 +327,7 @@ export class NotebookNavigatorSettingTab extends PluginSettingTab {
             buttonComponent.setButtonText(tab.label);
             buttonComponent.removeCta();
             buttonComponent.buttonEl.addClass('nn-settings-tab-button');
+            buttonComponent.buttonEl.addClass('clickable-icon');
             buttonComponent.buttonEl.setAttribute('role', 'tab');
             buttonComponent.onClick(() => {
                 this.activateTab(tab.id, tabs, contentWrapper);


### PR DESCRIPTION
## Description

This PR improves theme compatibility by adding standard Obsidian CSS classes to the settings tab navigation buttons.

## Changes

- Added `clickable-icon` class to all tab buttons

## Motivation

Currently, the settings UI uses custom class (`nn-settings-tab-button`) for styling tab buttons. While this works fine with themes that don't specifically style `<button>` elements, it breaks the visual feedback in themes that use actual button styling (such as [Retroma](https://github.com/emarpiee/Retroma)).

Many Obsidian themes rely on standard classes like `clickable-icon` to apply proper button states. Without these classes, the tab buttons in such themes don't look or behave like buttons at all — active buttons don't appear pressed/selected, making it impossible to tell which settings tab is currently active.

**In button-themed UIs:** Without the standard classes, all tab buttons look identical (unpressed), regardless of which tab is active. With the standard classes, active buttons appear visually pressed/selected as expected.

**In non-button themes:** Everything works fine both before and after this change, since they don't specifically style button elements.

## Implementation

This change adds the standard class alongside existing ones, ensuring:
- Proper button appearance in button-based themes
- Uses CSS classes that are de-facto standard in the Obsidian theme ecosystem
- No breaking changes to existing functionality
- No visual changes for themes that don't use button-specific styling

## Screenshots

### Before
In button-based themes like Retroma, tab buttons don't appear pressed/selected. All buttons look the same, making it unclear which tab is active.
<img width="839" height="285" alt="before" src="https://github.com/user-attachments/assets/91e25fbf-420b-420f-b031-70ae96a80238" />

### After
Active tab buttons now display correctly with proper button states across all themes, including those with button-specific styling.
<img width="842" height="285" alt="after" src="https://github.com/user-attachments/assets/699b9027-addf-464f-a105-925ea5caad64" />