### PR TITLE
feat: add 'Ask' option to folder note type selector

### DIFF
--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -320,6 +320,12 @@ export const STRINGS_DE = {
                 add: 'zum Hinzufügen des Tags',
                 remove: 'zum Entfernen des Tags'
             }
+        },
+        folderNoteType: {
+            title: 'Ordnernotiztyp wählen',
+            markdown: 'Markdown',
+            canvas: 'Canvas',
+            base: 'Base'
         }
     },
 
@@ -890,7 +896,8 @@ export const STRINGS_DE = {
                 options: {
                     markdown: 'Markdown',
                     canvas: 'Canvas',
-                    base: 'Base'
+                    base: 'Base',
+                    ask: 'Beim Erstellen fragen'
                 }
             },
             folderNoteName: {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -318,6 +318,12 @@ export const STRINGS_EN = {
                 add: 'to add tag',
                 remove: 'to remove tag'
             }
+        },
+        folderNoteType: {
+            title: 'Choose folder note type',
+            markdown: 'Markdown',
+            canvas: 'Canvas',
+            base: 'Base'
         }
     },
     // File system operations
@@ -886,7 +892,8 @@ export const STRINGS_EN = {
                 options: {
                     markdown: 'Markdown',
                     canvas: 'Canvas',
-                    base: 'Base'
+                    base: 'Base',
+                    ask: 'Ask when creating'
                 }
             },
             folderNoteName: {

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -318,6 +318,12 @@ export const STRINGS_ES = {
                 add: 'para añadir etiqueta',
                 remove: 'para eliminar etiqueta'
             }
+        },
+        folderNoteType: {
+            title: 'Elegir tipo de nota de carpeta',
+            markdown: 'Markdown',
+            canvas: 'Canvas',
+            base: 'Base'
         }
     },
 
@@ -887,7 +893,8 @@ export const STRINGS_ES = {
                 options: {
                     markdown: 'Markdown',
                     canvas: 'Canvas',
-                    base: 'Base'
+                    base: 'Base',
+                    ask: 'Preguntar al crear'
                 }
             },
             folderNoteName: {

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -318,6 +318,12 @@ export const STRINGS_FR = {
                 add: "pour ajouter l'étiquette",
                 remove: "pour supprimer l'étiquette"
             }
+        },
+        folderNoteType: {
+            title: 'Choisir le type de note de dossier',
+            markdown: 'Markdown',
+            canvas: 'Canvas',
+            base: 'Base'
         }
     },
 
@@ -889,7 +895,8 @@ export const STRINGS_FR = {
                 options: {
                     markdown: 'Markdown',
                     canvas: 'Canvas',
-                    base: 'Base'
+                    base: 'Base',
+                    ask: 'Demander lors de la création'
                 }
             },
             folderNoteName: {

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -318,6 +318,12 @@ export const STRINGS_JA = {
                 add: 'タグを追加',
                 remove: 'タグを削除'
             }
+        },
+        folderNoteType: {
+            title: 'フォルダノートの種類を選択',
+            markdown: 'Markdown',
+            canvas: 'Canvas',
+            base: 'Base'
         }
     },
 
@@ -888,7 +894,8 @@ export const STRINGS_JA = {
                 options: {
                     markdown: 'Markdown',
                     canvas: 'Canvas',
-                    base: 'Base'
+                    base: 'Base',
+                    ask: '作成時に確認'
                 }
             },
             folderNoteName: {

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -317,6 +317,12 @@ export const STRINGS_KO = {
                 add: '태그 추가',
                 remove: '태그 제거'
             }
+        },
+        folderNoteType: {
+            title: '폴더 노트 유형 선택',
+            markdown: 'Markdown',
+            canvas: 'Canvas',
+            base: 'Base'
         }
     },
 
@@ -886,7 +892,8 @@ export const STRINGS_KO = {
                 options: {
                     markdown: 'Markdown',
                     canvas: 'Canvas',
-                    base: 'Base'
+                    base: 'Base',
+                    ask: '생성 시 묻기'
                 }
             },
             folderNoteName: {

--- a/src/i18n/locales/pl.ts
+++ b/src/i18n/locales/pl.ts
@@ -319,6 +319,12 @@ export const STRINGS_PL = {
                 add: 'aby dodać tag',
                 remove: 'aby usunąć tag'
             }
+        },
+        folderNoteType: {
+            title: 'Wybierz typ notatki folderu',
+            markdown: 'Markdown',
+            canvas: 'Canvas',
+            base: 'Base'
         }
     },
 
@@ -888,7 +894,8 @@ export const STRINGS_PL = {
                 options: {
                     markdown: 'Markdown',
                     canvas: 'Canvas',
-                    base: 'Base'
+                    base: 'Base',
+                    ask: 'Pytaj podczas tworzenia'
                 }
             },
             folderNoteName: {

--- a/src/i18n/locales/zh_cn.ts
+++ b/src/i18n/locales/zh_cn.ts
@@ -318,6 +318,12 @@ export const STRINGS_ZH_CN = {
                 add: '添加标签',
                 remove: '移除标签'
             }
+        },
+        folderNoteType: {
+            title: '选择文件夹笔记类型',
+            markdown: 'Markdown',
+            canvas: 'Canvas',
+            base: 'Base'
         }
     },
 
@@ -887,7 +893,8 @@ export const STRINGS_ZH_CN = {
                 options: {
                     markdown: 'Markdown',
                     canvas: 'Canvas',
-                    base: 'Base'
+                    base: 'Base',
+                    ask: '创建时询问'
                 }
             },
             folderNoteName: {

--- a/src/i18n/locales/zh_tw.ts
+++ b/src/i18n/locales/zh_tw.ts
@@ -318,6 +318,12 @@ export const STRINGS_ZH_TW = {
                 add: '新增標籤',
                 remove: '移除標籤'
             }
+        },
+        folderNoteType: {
+            title: '選擇資料夾筆記類型',
+            markdown: 'Markdown',
+            canvas: 'Canvas',
+            base: 'Base'
         }
     },
     // 檔案系統操作
@@ -885,7 +891,8 @@ export const STRINGS_ZH_TW = {
                 options: {
                     markdown: 'Markdown',
                     canvas: '畫布',
-                    base: 'Base'
+                    base: 'Base',
+                    ask: '建立時詢問'
                 }
             },
             folderNoteName: {

--- a/src/modals/FolderNoteTypeModal.ts
+++ b/src/modals/FolderNoteTypeModal.ts
@@ -1,0 +1,114 @@
+/*
+ * Notebook Navigator - Plugin for Obsidian
+ * Copyright (c) 2025 Johan Sanneblad
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { App, Modal } from 'obsidian';
+import { strings } from '../i18n';
+import { FolderNoteType } from '../types/folderNote';
+
+/**
+ * Modal dialog for choosing a folder note type
+ * Displays three buttons: Markdown, Canvas, and Base
+ * Used when the user has selected "Ask" as their folder note type preference
+ */
+export class FolderNoteTypeModal extends Modal {
+    private markdownBtn: HTMLButtonElement;
+    private canvasBtn: HTMLButtonElement;
+    private baseBtn: HTMLButtonElement;
+    private cancelBtn: HTMLButtonElement;
+    private markdownHandler: () => void;
+    private canvasHandler: () => void;
+    private baseHandler: () => void;
+    private cancelHandler: () => void;
+
+    /**
+     * Creates a folder note type selection modal
+     * @param app - The Obsidian app instance
+     * @param onSelect - Callback to execute when user selects a type, receives the selected type
+     */
+    constructor(app: App, private onSelect: (type: Exclude<FolderNoteType, 'ask'>) => void) {
+        super(app);
+        this.titleEl.setText(strings.modals.folderNoteType.title);
+
+        const buttonContainer = this.contentEl.createDiv('nn-button-container-vertical');
+
+        // Store references for cleanup
+        this.markdownHandler = () => {
+            this.close();
+            this.onSelect('markdown');
+        };
+
+        this.canvasHandler = () => {
+            this.close();
+            this.onSelect('canvas');
+        };
+
+        this.baseHandler = () => {
+            this.close();
+            this.onSelect('base');
+        };
+
+        this.cancelHandler = () => this.close();
+
+        // Create buttons for each type
+        this.markdownBtn = buttonContainer.createEl('button', {
+            text: strings.modals.folderNoteType.markdown
+        });
+        this.markdownBtn.addEventListener('click', this.markdownHandler);
+
+        this.canvasBtn = buttonContainer.createEl('button', {
+            text: strings.modals.folderNoteType.canvas
+        });
+        this.canvasBtn.addEventListener('click', this.canvasHandler);
+
+        this.baseBtn = buttonContainer.createEl('button', {
+            text: strings.modals.folderNoteType.base
+        });
+        this.baseBtn.addEventListener('click', this.baseHandler);
+
+        this.cancelBtn = buttonContainer.createEl('button', {
+            text: strings.common.cancel,
+            cls: 'mod-warning'
+        });
+        this.cancelBtn.addEventListener('click', this.cancelHandler);
+
+        // Keyboard shortcuts
+        this.scope.register([], 'Escape', evt => {
+            evt.preventDefault();
+            this.close();
+        });
+    }
+
+    /**
+     * Cleanup event listeners when modal is closed
+     * Prevents memory leaks by removing all event listeners
+     */
+    onClose() {
+        if (this.markdownBtn && this.markdownHandler) {
+            this.markdownBtn.removeEventListener('click', this.markdownHandler);
+        }
+        if (this.canvasBtn && this.canvasHandler) {
+            this.canvasBtn.removeEventListener('click', this.canvasHandler);
+        }
+        if (this.baseBtn && this.baseHandler) {
+            this.baseBtn.removeEventListener('click', this.baseHandler);
+        }
+        if (this.cancelBtn && this.cancelHandler) {
+            this.cancelBtn.removeEventListener('click', this.cancelHandler);
+        }
+    }
+}

--- a/src/settings/tabs/FoldersTagsTab.ts
+++ b/src/settings/tabs/FoldersTagsTab.ts
@@ -70,6 +70,7 @@ export function renderFoldersTagsTab(context: SettingsTabContext): void {
                 .addOption('markdown', strings.settings.items.folderNoteType.options.markdown)
                 .addOption('canvas', strings.settings.items.folderNoteType.options.canvas)
                 .addOption('base', strings.settings.items.folderNoteType.options.base)
+                .addOption('ask', strings.settings.items.folderNoteType.options.ask)
                 .setValue(plugin.settings.folderNoteType)
                 .onChange(async value => {
                     if (!isFolderNoteType(value)) {

--- a/src/types/folderNote.ts
+++ b/src/types/folderNote.ts
@@ -16,14 +16,14 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-export type FolderNoteType = 'markdown' | 'canvas' | 'base';
+export type FolderNoteType = 'markdown' | 'canvas' | 'base' | 'ask';
 
-export const FOLDER_NOTE_TYPE_EXTENSIONS: Record<FolderNoteType, string> = {
+export const FOLDER_NOTE_TYPE_EXTENSIONS: Record<Exclude<FolderNoteType, 'ask'>, string> = {
     markdown: 'md',
     canvas: 'canvas',
     base: 'base'
 };
 
 export function isFolderNoteType(value: string): value is FolderNoteType {
-    return value === 'markdown' || value === 'canvas' || value === 'base';
+    return value === 'markdown' || value === 'canvas' || value === 'base' || value === 'ask';
 }

--- a/src/utils/contextMenu/folderMenuBuilder.ts
+++ b/src/utils/contextMenu/folderMenuBuilder.ts
@@ -219,27 +219,42 @@ export function buildFolderMenu(params: FolderMenuBuilderParams): void {
                 item.setTitle(strings.contextMenu.folder.createFolderNote)
                     .setIcon('lucide-pen-box')
                     .onClick(async () => {
-                        const createdNote = await createFolderNote(
-                            app,
-                            folder,
-                            {
-                                folderNoteType: settings.folderNoteType,
-                                folderNoteName: settings.folderNoteName,
-                                folderNoteProperties: settings.folderNoteProperties
-                            },
-                            services.commandQueue
-                        );
-                        if (createdNote && settings.pinCreatedFolderNote) {
-                            try {
-                                if (!metadataService.isFilePinned(createdNote.path, 'folder')) {
-                                    await metadataService.togglePin(createdNote.path, 'folder');
+                        // Helper function to create a folder note with a specific type
+                        const createNote = async (folderNoteType: 'markdown' | 'canvas' | 'base') => {
+                            const createdNote = await createFolderNote(
+                                app,
+                                folder,
+                                {
+                                    folderNoteType,
+                                    folderNoteName: settings.folderNoteName,
+                                    folderNoteProperties: settings.folderNoteProperties
+                                },
+                                services.commandQueue
+                            );
+                            if (createdNote && settings.pinCreatedFolderNote) {
+                                try {
+                                    if (!metadataService.isFilePinned(createdNote.path, 'folder')) {
+                                        await metadataService.togglePin(createdNote.path, 'folder');
+                                    }
+                                } catch (error) {
+                                    console.error('Failed to pin created folder note', {
+                                        path: createdNote.path,
+                                        error
+                                    });
                                 }
-                            } catch (error) {
-                                console.error('Failed to pin created folder note', {
-                                    path: createdNote.path,
-                                    error
-                                });
                             }
+                        };
+
+                        // If "ask" is selected, show modal to choose type
+                        if (settings.folderNoteType === 'ask') {
+                            const { FolderNoteTypeModal } = await import('../../modals/FolderNoteTypeModal');
+                            const modal = new FolderNoteTypeModal(app, async selectedType => {
+                                await createNote(selectedType);
+                            });
+                            modal.open();
+                        } else {
+                            // Otherwise, use the default type from settings
+                            await createNote(settings.folderNoteType);
                         }
                     });
             });

--- a/src/utils/folderNotes.ts
+++ b/src/utils/folderNotes.ts
@@ -32,9 +32,11 @@ export interface FolderNoteDetectionSettings {
 
 /**
  * Settings required for creating folder notes
+ * Note: folderNoteType excludes 'ask' because by the time this function is called,
+ * the user has already selected a specific type (via modal or settings)
  */
 export interface FolderNoteCreationSettings {
-    folderNoteType: FolderNoteType;
+    folderNoteType: Exclude<FolderNoteType, 'ask'>;
     folderNoteName: string;
     folderNoteProperties: string[];
 }

--- a/styles.css
+++ b/styles.css
@@ -2531,6 +2531,14 @@ body.nn-resizing {
     margin-top: 16px;
 }
 
+/* Modal button container - vertical layout for stacked buttons */
+.nn-button-container-vertical {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-top: 16px;
+}
+
 /* ========================================================================
    What's New Modal
    ======================================================================== */


### PR DESCRIPTION
## Description
  
This PR adds a new 'Ask' option to folder note type settings that prompts users to choose between Markdown, Canvas, or Base when creating a folder note.

## Changes
  - Added `'ask'` as a new `FolderNoteType` option in type definitions
  - Created `FolderNoteTypeModal` component with vertical button layout for type selection
  - Added i18n translations for all 9 supported languages (en, de, es, fr, ja, ko, pl, zh_cn, zh_tw)
  - Added CSS styling for vertical button layout (`.nn-button-container-vertical`)

## Motivation
Previously, users had to commit to a single default folder note type (Markdown, Canvas, or Base) in their settings. This was limiting for users who:
  - Work with different types of notes depending on the context
  - Want flexibility when creating folder notes without changing settings each time
  - Use multiple note types across different folders in their vault

## Implementation
  This change adds an 'Ask when creating' option to the folder note type dropdown in settings. When selected:

  1. User right-clicks a folder and selects "Create folder note"
  2. A modal appears with three buttons arranged vertically:
     - **Markdown** - Creates a `.md` folder note
     - **Canvas** - Creates a `.canvas` folder note
     - **Base** - Creates a `.base` folder note
     - **Cancel**
  3. User selects their preferred type
  4. Folder note is created with the selected type

## Screenshots
<img width="766" height="411" alt="image" src="https://github.com/user-attachments/assets/cb8ccf58-f0bb-4b28-b7ee-d6f8ab817f4b" />
<img width="1487" height="1140" alt="image" src="https://github.com/user-attachments/assets/54e7a33c-ab5f-48e1-b53c-d5f588c210c3" />
