### PR TITLE
Fix: Tag Chevron Icons Flashing on Leaf Tags

### DIFF
--- a/src/components/TagTreeItem.tsx
+++ b/src/components/TagTreeItem.tsx
@@ -217,11 +217,16 @@ export const TagTreeItem = React.memo(
 
         // Update chevron icon based on expanded state
         React.useEffect(() => {
-            if (chevronRef.current && hasChildren) {
-                getIconService().renderIcon(
-                    chevronRef.current,
-                    resolveUXIcon(settings.interfaceIcons, isExpanded ? 'nav-tree-collapse' : 'nav-tree-expand')
-                );
+            if (chevronRef.current) {
+                if (hasChildren) {
+                    getIconService().renderIcon(
+                        chevronRef.current,
+                        resolveUXIcon(settings.interfaceIcons, isExpanded ? 'nav-tree-collapse' : 'nav-tree-expand')
+                    );
+                } else {
+                    // Clear the icon when there are no children to prevent stale icons from virtualized list reuse
+                    chevronRef.current.empty();
+                }
             }
         }, [hasChildren, iconVersion, isExpanded, settings.interfaceIcons]);
 


### PR DESCRIPTION
# Fix: Tag Chevron Icons Flashing on Leaf Tags

## Problem

When expanding a tag in the navigation pane, child tags with no nested children would briefly display a ">" (chevron) expand icon for approximately one second before disappearing. This created a confusing user experience where tags appeared to be expandable when they actually had no children.

## Root Cause

The issue stemmed from **DOM element reuse in the virtualized list**. For performance optimization, the navigation pane uses virtualization, which reuses DOM elements as items scroll in and out of view.

When a DOM element was reused:
1. A tag with children (e.g., "Azure") was rendered with a chevron icon
2. The user scrolled, and the DOM element was recycled
3. The same DOM element was reused for a child tag without children (e.g., "AutomationAccount")
4. **The old chevron icon remained in the DOM** until React's reconciliation cleared it

The problematic `useEffect` in `src/components/TagTreeItem.tsx` only set the chevron icon when `hasChildren` was true, but never explicitly cleared it when `hasChildren` was false:

```typescript
// Before (lines 219-226)
React.useEffect(() => {
    if (chevronRef.current && hasChildren) {
        getIconService().renderIcon(
            chevronRef.current,
            resolveUXIcon(settings.interfaceIcons, isExpanded ? 'nav-tree-collapse' : 'nav-tree-expand')
        );
    }
}, [hasChildren, iconVersion, isExpanded, settings.interfaceIcons]);
```

While CSS `visibility: hidden` would eventually hide the icon, there was a brief moment where the old icon remained visible, causing the flash effect.

## Solution

Modified the chevron icon rendering effect in `src/components/TagTreeItem.tsx` to explicitly clear the icon when `hasChildren` is false:

```typescript
// After (lines 219-231)
React.useEffect(() => {
    if (chevronRef.current) {
        if (hasChildren) {
            getIconService().renderIcon(
                chevronRef.current,
                resolveUXIcon(settings.interfaceIcons, isExpanded ? 'nav-tree-collapse' : 'nav-tree-expand')
            );
        } else {
            // Clear the icon when there are no children to prevent stale icons from virtualized list reuse
            chevronRef.current.empty();
        }
    }
}, [hasChildren, iconVersion, isExpanded, settings.interfaceIcons]);
```

**Key Changes:**
- Moved the `hasChildren` check inside the effect after the `chevronRef.current` check
- Added an `else` branch that calls `chevronRef.current.empty()` to explicitly remove all child nodes from the chevron element
- This ensures no stale icons remain when a DOM element is reused by the virtualized list
