### PR TITLE
Add navigation pane side setting (left/right)

### DIFF
--- a/src/components/NotebookNavigatorComponent.tsx
+++ b/src/components/NotebookNavigatorComponent.tsx
@@ -261,7 +261,8 @@ export const NotebookNavigatorComponent = React.memo(
             initialSize: navigationPaneDefaultSize,
             min: navigationPaneMinSize,
             storageKey: navigationPaneStorageKey,
-            scale: uiScale
+            scale: uiScale,
+            paneSide: settings.navigationPaneSide
         });
 
         // Tracks whether initial dual/single pane check has been performed
@@ -1140,6 +1141,7 @@ export const NotebookNavigatorComponent = React.memo(
                     }
                     data-navigator-focused={isMobile ? 'true' : isNavigatorFocused}
                     tabIndex={-1}
+                    data-pane-side={settings.navigationPaneSide}
                     onKeyDown={() => {
                         // Allow keyboard events to bubble up from child components
                         // The actual keyboard handling is done in NavigationPane and ListPane
@@ -1153,31 +1155,63 @@ export const NotebookNavigatorComponent = React.memo(
                 4. This allows Tab/Arrow navigation between panes while keeping
                    all keyboard events scoped to the navigator container only
             */}
-                    <NavigationPane
-                        ref={navigationPaneRef}
-                        style={navigationPaneStyle}
-                        uiScale={uiScale}
-                        rootContainerRef={containerRef}
-                        searchNavFilters={searchNavFilters}
-                        onExecuteSearchShortcut={handleSearchShortcutExecution}
-                        onNavigateToFolder={navigateToFolder}
-                        onRevealTag={revealTag}
-                        onRevealProperty={revealProperty}
-                        onRevealFile={revealFileInNearestFolder}
-                        onRevealShortcutFile={handleShortcutNoteReveal}
-                        onModifySearchWithTag={handleModifySearchWithTag}
-                        onModifySearchWithProperty={handleModifySearchWithProperty}
-                        onModifySearchWithDateFilter={handleModifySearchWithDateFilter}
-                    />
-                    <ListPane
-                        ref={listPaneRef}
-                        rootContainerRef={containerRef}
-                        onSearchTokensChange={handleSearchTokensChange}
-                        onNavigateToFolder={navigateToFolder}
-                        onRevealTag={revealTag}
-                        onRevealProperty={revealProperty}
-                        resizeHandleProps={!uiState.singlePane ? resizeHandleProps : undefined}
-                    />
+                    {settings.navigationPaneSide === 'right' ? (
+                        <>
+                            <ListPane
+                                ref={listPaneRef}
+                                rootContainerRef={containerRef}
+                                onSearchTokensChange={handleSearchTokensChange}
+                                onNavigateToFolder={navigateToFolder}
+                                onRevealTag={revealTag}
+                                onRevealProperty={revealProperty}
+                                resizeHandleProps={!uiState.singlePane ? resizeHandleProps : undefined}
+                            />
+                            <NavigationPane
+                                ref={navigationPaneRef}
+                                style={navigationPaneStyle}
+                                uiScale={uiScale}
+                                rootContainerRef={containerRef}
+                                searchNavFilters={searchNavFilters}
+                                onExecuteSearchShortcut={handleSearchShortcutExecution}
+                                onNavigateToFolder={navigateToFolder}
+                                onRevealTag={revealTag}
+                                onRevealProperty={revealProperty}
+                                onRevealFile={revealFileInNearestFolder}
+                                onRevealShortcutFile={handleShortcutNoteReveal}
+                                onModifySearchWithTag={handleModifySearchWithTag}
+                                onModifySearchWithProperty={handleModifySearchWithProperty}
+                                onModifySearchWithDateFilter={handleModifySearchWithDateFilter}
+                            />
+                        </>
+                    ) : (
+                        <>
+                            <NavigationPane
+                                ref={navigationPaneRef}
+                                style={navigationPaneStyle}
+                                uiScale={uiScale}
+                                rootContainerRef={containerRef}
+                                searchNavFilters={searchNavFilters}
+                                onExecuteSearchShortcut={handleSearchShortcutExecution}
+                                onNavigateToFolder={navigateToFolder}
+                                onRevealTag={revealTag}
+                                onRevealProperty={revealProperty}
+                                onRevealFile={revealFileInNearestFolder}
+                                onRevealShortcutFile={handleShortcutNoteReveal}
+                                onModifySearchWithTag={handleModifySearchWithTag}
+                                onModifySearchWithProperty={handleModifySearchWithProperty}
+                                onModifySearchWithDateFilter={handleModifySearchWithDateFilter}
+                            />
+                            <ListPane
+                                ref={listPaneRef}
+                                rootContainerRef={containerRef}
+                                onSearchTokensChange={handleSearchTokensChange}
+                                onNavigateToFolder={navigateToFolder}
+                                onRevealTag={revealTag}
+                                onRevealProperty={revealProperty}
+                                resizeHandleProps={!uiState.singlePane ? resizeHandleProps : undefined}
+                            />
+                        </>
+                    )}
                     {shouldRenderSinglePaneCalendar ? (
                         <div className="nn-single-pane-calendar">
                             <Calendar

--- a/src/hooks/useResizablePane.ts
+++ b/src/hooks/useResizablePane.ts
@@ -29,6 +29,7 @@ interface UseResizablePaneConfig {
     min?: number;
     storageKey?: string;
     scale?: number;
+    paneSide?: 'left' | 'right';
 }
 
 interface UseResizablePaneResult {
@@ -52,7 +53,8 @@ export function useResizablePane({
     initialSize,
     min,
     storageKey,
-    scale
+    scale,
+    paneSide = 'left'
 }: UseResizablePaneConfig = {}): UseResizablePaneResult {
     // Get default sizing parameters for orientation
     const sizing = getNavigationPaneSizing(orientation);
@@ -108,6 +110,10 @@ export function useResizablePane({
                     if (isRTL) {
                         delta = -delta;
                     }
+                    // Reverse delta when nav pane is on the right
+                    if (orientation === 'horizontal' && paneSide === 'right') {
+                        delta = -delta;
+                    }
                     const scaledDelta = delta / scaleFactor;
                     currentSize = Math.max(resolvedMin, startSize + scaledDelta);
                     setPaneSize(currentSize);
@@ -122,7 +128,7 @@ export function useResizablePane({
                 }
             });
         },
-        [orientation, paneSize, resolvedMin, scaleFactor, storageKey, startPointerDrag]
+        [orientation, paneSize, paneSide, resolvedMin, scaleFactor, storageKey, startPointerDrag]
     );
 
     // Reload pane size when orientation changes

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,6 +42,7 @@ import {
     NOTEBOOK_NAVIGATOR_VIEW,
     STORAGE_KEYS,
     type DualPaneOrientation,
+    type NavigationPaneSide,
     type UXPreferences,
     type VisibilityPreferences
 } from './types';
@@ -1162,6 +1163,32 @@ export default class NotebookNavigatorPlugin extends Plugin implements ISettings
         this.settings.dualPaneOrientation = normalized;
         localStorage.set(this.keys.dualPaneOrientationKey, normalized);
         await this.persistSyncModeSettingUpdateAsync('dualPaneOrientation');
+    }
+
+    /**
+     * Returns the navigation pane side preference (left or right).
+     */
+    public getNavigationPaneSide(): NavigationPaneSide {
+        if (this.isLocal('navigationPaneSide')) {
+            const stored = localStorage.get<NavigationPaneSide>(this.keys.navigationPaneSideKey);
+            return stored === 'left' || stored === 'right' ? stored : 'left';
+        }
+        return this.settings.navigationPaneSide === 'right' ? 'right' : 'left';
+    }
+
+    /**
+     * Updates the navigation pane side and persists to storage.
+     */
+    public setNavigationPaneSide(side: NavigationPaneSide): void {
+        const sanitized: NavigationPaneSide = side === 'right' ? 'right' : 'left';
+        
+        this.updateSettingAndMirrorToLocalStorage({
+            settingId: 'navigationPaneSide',
+            localStorageKey: this.keys.navigationPaneSideKey,
+            nextValue: sanitized
+        });
+        
+        this.persistSyncModeSettingUpdate('navigationPaneSide');
     }
 
     /**

--- a/src/services/commands/registerNavigatorCommands.ts
+++ b/src/services/commands/registerNavigatorCommands.ts
@@ -1425,4 +1425,16 @@ export default function registerNavigatorCommands(plugin: NotebookNavigatorPlugi
             return true;
         }
     });
+
+    // Command to toggle navigation pane side
+    plugin.addCommand({
+        id: 'toggle-navigation-pane-side',
+        name: 'Toggle navigation pane side (left/right)',
+        callback: () => {
+            const currentSide = plugin.getNavigationPaneSide();
+            const newSide = currentSide === 'left' ? 'right' : 'left';
+            plugin.setNavigationPaneSide(newSide);
+            showNotice(`Navigation pane moved to ${newSide}`);
+        }
+    });
 }

--- a/src/services/settings/syncModeRegistry.ts
+++ b/src/services/settings/syncModeRegistry.ts
@@ -456,6 +456,21 @@ export function createSyncModeRegistry(params: CreateSyncModeRegistryParams): Sy
                 const next = sanitizeUIScale(Platform.isMobile ? settings.mobileScale : settings.desktopScale);
                 setLocalStorage(params.keys.uiScaleKey, next);
             }
+        }),
+        navigationPaneSide: createResolvedLocalStorageSettingEntry({
+            settingId: 'navigationPaneSide',
+            loadPhase: 'preProfiles',
+            localStorageKey: params.keys.navigationPaneSideKey,
+            resolveDeviceLocal: storedData => {
+                const value = typeof storedData === 'string' && (storedData === 'left' || storedData === 'right') 
+                    ? storedData 
+                    : params.defaultSettings.navigationPaneSide;
+                return { value, migrated: false };
+            },
+            sanitizeSynced: () => {
+                const value = params.getSettings().navigationPaneSide;
+                return value === 'right' ? 'right' : 'left';
+            }
         })
     };
 }

--- a/src/settings/defaultSettings.ts
+++ b/src/settings/defaultSettings.ts
@@ -89,6 +89,7 @@ export const DEFAULT_SETTINGS: NotebookNavigatorSettings = {
     // General tab - Desktop appearance
     dualPane: true,
     dualPaneOrientation: 'horizontal',
+    navigationPaneSide: 'left',
     showTooltips: false,
     showTooltipPath: true,
     desktopBackground: 'separate',

--- a/src/settings/tabs/GeneralTab.ts
+++ b/src/settings/tabs/GeneralTab.ts
@@ -768,6 +768,26 @@ export function renderGeneralTab(context: SettingsTabContext): void {
 
         addSettingSyncModeToggle({ setting: dualPaneOrientationSetting, plugin, settingId: 'dualPaneOrientation' });
 
+        const navigationPaneSideSetting = desktopAppearanceGroup.addSetting(setting => {
+            setting
+                .setName('Navigation pane side')
+                .setDesc('Choose which side the navigation pane appears on (horizontal mode only)')
+                .addDropdown(dropdown => {
+                    dropdown
+                        .addOptions({
+                            left: 'Left (default)',
+                            right: 'Right'
+                        })
+                        .setValue(plugin.getNavigationPaneSide())
+                        .onChange(async value => {
+                            const nextValue = value === 'right' ? 'right' : 'left';
+                            plugin.setNavigationPaneSide(nextValue);
+                        });
+                });
+        });
+
+        addSettingSyncModeToggle({ setting: navigationPaneSideSetting, plugin, settingId: 'navigationPaneSide' });
+
         desktopAppearanceGroup.addSetting(setting => {
             setting
                 .setName(strings.settings.items.appearanceBackground.name)

--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -18,7 +18,7 @@
 
 import type { FileVisibility } from '../utils/fileTypeUtils';
 import type { FolderAppearance, TagAppearance } from '../hooks/useListPaneAppearance';
-import type { BackgroundMode, DualPaneOrientation, PinnedNotes } from '../types';
+import type { BackgroundMode, DualPaneOrientation, NavigationPaneSide, PinnedNotes } from '../types';
 import type { FolderNoteCreationPreference } from '../types/folderNote';
 import type { KeyboardShortcutConfig } from '../utils/keyboardShortcuts';
 import type { ShortcutEntry } from '../types/shortcuts';
@@ -60,6 +60,7 @@ export const SYNC_MODE_SETTING_IDS = [
     'useFloatingToolbars',
     'dualPane',
     'dualPaneOrientation',
+    'navigationPaneSide',
     'paneTransitionDuration',
     'toolbarVisibility',
     'pinNavigationBanner',
@@ -272,6 +273,7 @@ export interface NotebookNavigatorSettings {
     // General tab - Desktop appearance
     dualPane: boolean;
     dualPaneOrientation: DualPaneOrientation;
+    navigationPaneSide: NavigationPaneSide;
     showTooltips: boolean;
     showTooltipPath: boolean;
     desktopBackground: BackgroundMode;

--- a/src/styles/sections/layout-panes.css
+++ b/src/styles/sections/layout-panes.css
@@ -19,6 +19,17 @@
     contain: layout style;
 }
 
+/* Nav-right mode: swap borders */
+.nn-split-container[data-pane-side="right"] .nn-navigation-pane {
+    border-right: none;
+    border-left: 1px solid var(--nn-theme-divider-border-color);
+}
+
+.nn-split-container[data-pane-side="right"] .nn-resize-handle {
+    left: auto;
+    right: 0;
+}
+
 /* Right pane - contains the file list */
 .nn-list-pane {
     flex: 1;

--- a/src/types.ts
+++ b/src/types.ts
@@ -252,6 +252,7 @@ export interface LocalStorageKeys {
     navigationPaneHeightKey: string;
     dualPaneOrientationKey: string;
     dualPaneKey: string;
+    navigationPaneSideKey: string;
     uiScaleKey: string;
     shortcutsExpandedKey: string;
     recentNotesExpandedKey: string;
@@ -305,6 +306,7 @@ export const STORAGE_KEYS: LocalStorageKeys = {
     navigationPaneHeightKey: 'notebook-navigator-navigation-pane-height',
     dualPaneOrientationKey: 'notebook-navigator-dual-pane-orientation',
     dualPaneKey: 'notebook-navigator-dual-pane',
+    navigationPaneSideKey: 'notebook-navigator-navigation-pane-side',
     uiScaleKey: 'notebook-navigator-ui-scale',
     shortcutsExpandedKey: 'notebook-navigator-shortcuts-expanded',
     recentNotesExpandedKey: 'notebook-navigator-recent-notes-expanded',
@@ -352,6 +354,9 @@ export type VisibilityPreferences = Pick<UXPreferences, 'includeDescendantNotes'
 
 /** Orientation options for dual-pane layout */
 export type DualPaneOrientation = 'horizontal' | 'vertical';
+
+/** Side where the navigation pane appears in horizontal dual-pane mode */
+export type NavigationPaneSide = 'left' | 'right';
 
 /** Background color mode for navigation/list panes on desktop */
 export type BackgroundMode = 'separate' | 'primary' | 'secondary';


### PR DESCRIPTION
## Summary

Adds a configurable setting to allow users to choose whether the navigation pane appears on the left (default) or right side of the Notebook Navigator interface.

## Changes

- **Settings Infrastructure**: Added `NavigationPaneSide` type, storage keys, defaults, and sync mode support
- **UI Control**: Added dropdown in General settings tab under Desktop Appearance section
- **Pane Rendering**: Conditional DOM ordering based on setting value
- **CSS Updates**: Added styles for nav-right mode (borders, resize handle positioning)
- **Resize Logic**: Fixed delta reversal when navigation pane is on the right
- **Toggle Command**: Added command palette command for quick switching
- **Sync Support**: Full cross-device synchronization support

## Testing

- [x] Setting appears in General tab
- [x] Panes swap correctly when changing setting
- [x] Resize handle follows the pane and works in both modes
- [x] Drag-and-drop functionality works in both configurations
- [x] Keyboard navigation works correctly (Tab, arrows)
- [x] Toggle command works from command palette
- [x] Settings persist across reloads
- [x] Sync mode support for cross-device settings

## Screenshots

<img width="1384" height="804" alt="image" src="https://github.com/user-attachments/assets/73ffa551-7f36-4741-b957-2e1399791797" />


## Related Issues

Resolves user request for configurable navigation pane positioning to support right-side navigation with file list on the left.