### PR TITLE
Add tag-scoped pin ordering for tag views

### DIFF
--- a/src/api/modules/MetadataAPI.ts
+++ b/src/api/modules/MetadataAPI.ts
@@ -694,6 +694,18 @@ export class MetadataAPI {
     }
 
     /**
+     * Check whether a file is pinned for a specific tag view only.
+     */
+    isPinnedInTagView(file: TFile, tagPath: string): boolean {
+        const plugin = this.api.getPlugin();
+        if (!plugin?.metadataService) {
+            return false;
+        }
+
+        return plugin.metadataService.isFilePinnedInTagView(file.path, tagPath);
+    }
+
+    /**
      * Pin a file
      * @param file - File to pin
      * @param context - Context to pin in (defaults to 'all')
@@ -746,6 +758,20 @@ export class MetadataAPI {
     }
 
     /**
+     * Pin a file for a single tag view only.
+     */
+    async pinInTagView(file: TFile, tagPath: string): Promise<void> {
+        const plugin = this.api.getPlugin();
+        if (!plugin?.metadataService) {
+            return;
+        }
+
+        if (!plugin.metadataService.isFilePinnedInTagView(file.path, tagPath)) {
+            await plugin.metadataService.togglePinnedInTagView(file.path, tagPath);
+        }
+    }
+
+    /**
      * Unpin a file
      * @param file - File to unpin
      * @param context - Context to unpin from (defaults to 'all')
@@ -791,6 +817,20 @@ export class MetadataAPI {
         // Save settings if anything changed
         if (changed) {
             await plugin.saveSettingsAndUpdate();
+        }
+    }
+
+    /**
+     * Unpin a file from a single tag view only.
+     */
+    async unpinFromTagView(file: TFile, tagPath: string): Promise<void> {
+        const plugin = this.api.getPlugin();
+        if (!plugin?.metadataService) {
+            return;
+        }
+
+        if (plugin.metadataService.isFilePinnedInTagView(file.path, tagPath)) {
+            await plugin.metadataService.togglePinnedInTagView(file.path, tagPath);
         }
     }
 

--- a/src/api/public/notebook-navigator.d.ts
+++ b/src/api/public/notebook-navigator.d.ts
@@ -339,10 +339,16 @@ export interface NotebookNavigatorAPI {
         getPinned(): Readonly<Pinned>;
         /** Check if a file is pinned (no context = any, 'all' = all contexts) */
         isPinned(file: TFile, context?: PinContext): boolean;
+        /** Check whether a file is pinned in one specific tag view */
+        isPinnedInTagView(file: TFile, tagPath: string): boolean;
         /** Pin a file (defaults to 'all' - all contexts) */
         pin(file: TFile, context?: PinContext): Promise<void>;
+        /** Pin a file in one specific tag view only */
+        pinInTagView(file: TFile, tagPath: string): Promise<void>;
         /** Unpin a file (defaults to 'all' - all contexts) */
         unpin(file: TFile, context?: PinContext): Promise<void>;
+        /** Unpin a file from one specific tag view only */
+        unpinFromTagView(file: TFile, tagPath: string): Promise<void>;
     };
 
     /** Navigation operations */

--- a/src/components/FileItem.tsx
+++ b/src/components/FileItem.tsx
@@ -44,6 +44,7 @@ import { useMetadataService } from '../context/ServicesContext';
 import { useSettingsDerived, useSettingsState } from '../context/SettingsContext';
 import { useUXPreferences } from '../context/UXPreferencesContext';
 import { useFileCache } from '../context/StorageContext';
+import { useSelectionState } from '../context/SelectionContext';
 import { useContextMenu } from '../hooks/useContextMenu';
 import { useListPaneAppearance } from '../hooks/useListPaneAppearance';
 import { useShortcuts } from '../context/ShortcutsContext';
@@ -105,6 +106,7 @@ interface FileItemProps {
     visiblePropertyKeys: ReadonlySet<string>;
     /** Visible frontmatter property keys in navigation pane (normalized keys) */
     visibleNavigationPropertyKeys: ReadonlySet<string>;
+    disableNativeDrag?: boolean;
 }
 
 /**
@@ -288,11 +290,13 @@ export const FileItem = React.memo(function FileItem({
     localDayReference,
     fileIconSize,
     visiblePropertyKeys,
-    visibleNavigationPropertyKeys
+    visibleNavigationPropertyKeys,
+    disableNativeDrag = false
 }: FileItemProps) {
     // === Hooks (all hooks together at the top) ===
     const { app, isMobile, plugin, commandQueue, tagOperations } = useServices();
     const settings = useSettingsState();
+    const selectionState = useSelectionState();
     const { fileNameIconNeedles } = useSettingsDerived();
     const uxPreferences = useUXPreferences();
     const includeDescendantNotes = uxPreferences.includeDescendantNotes;
@@ -785,7 +789,10 @@ export const FileItem = React.memo(function FileItem({
     };
 
     const pinContext = getNavigatorPinContext(selectionType ?? null);
-    const isPinnedInCurrentContext = metadataService.isFilePinned(file.path, pinContext);
+    const isPinnedInCurrentContext =
+        selectionState.selectionType === ItemType.TAG && selectionState.selectedTag
+            ? metadataService.isFilePinnedInTagView(file.path, selectionState.selectedTag)
+            : metadataService.isFilePinned(file.path, pinContext);
 
     // Quick action handlers - these don't need memoization because:
     // 1. They're only attached to DOM elements that appear on hover
@@ -803,6 +810,11 @@ export const FileItem = React.memo(function FileItem({
         e.preventDefault();
         runAsyncAction(async () => {
             if (!file.parent) {
+                return;
+            }
+
+            if (selectionState.selectionType === ItemType.TAG && selectionState.selectedTag) {
+                await metadataService.togglePinnedInTagView(file.path, selectionState.selectedTag);
                 return;
             }
 
@@ -1010,14 +1022,14 @@ export const FileItem = React.memo(function FileItem({
             // Type of item being dragged (folder, file, or tag)
             data-drag-type="file"
             // Marks element as draggable for event delegation
-            data-draggable={!isMobile ? 'true' : undefined}
+            data-draggable={!isMobile && !disableNativeDrag ? 'true' : undefined}
             // Icon to display in drag ghost
             data-drag-icon={dragIconId}
             // Icon color to display in drag ghost
             data-drag-icon-color={dragIconColor}
             onClick={handleItemClick}
             onMouseDown={handleMouseDown}
-            draggable={!isMobile}
+            draggable={!isMobile && !disableNativeDrag}
             role="listitem"
             onMouseEnter={() => !isMobile && setIsHovered(true)}
             onMouseLeave={() => !isMobile && setIsHovered(false)}

--- a/src/components/ListPane.tsx
+++ b/src/components/ListPane.tsx
@@ -518,6 +518,7 @@ export const ListPane = React.memo(
                         settings={settings}
                         pinnedSectionIcon={pinnedSectionIcon}
                         selectionType={selectionType}
+                        selectedTag={selectedTag}
                         sortOption={effectiveSortOption}
                         searchHighlightQuery={searchHighlightQuery}
                         isFolderNavigation={selectionState.isFolderNavigation}

--- a/src/components/listPane/ListPaneVirtualContent.tsx
+++ b/src/components/listPane/ListPaneVirtualContent.tsx
@@ -17,12 +17,16 @@
  */
 
 import React, { useCallback, useMemo } from 'react';
+import { DndContext, MouseSensor, TouchSensor, type DragEndEvent, useSensor, useSensors } from '@dnd-kit/core';
+import { SortableContext, arrayMove, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import { TFile, TFolder } from 'obsidian';
 import { Virtualizer } from '@tanstack/react-virtual';
-import { useServices } from '../../context/ServicesContext';
+import { useMetadataService, useServices } from '../../context/ServicesContext';
 import { strings } from '../../i18n';
-import { ListPaneItemType, PINNED_SECTION_HEADER_KEY, type NavigationItemType } from '../../types';
+import { ItemType, ListPaneItemType, PINNED_SECTION_HEADER_KEY, type NavigationItemType } from '../../types';
 import { runAsyncAction } from '../../utils/async';
+import { ROOT_REORDER_MOUSE_CONSTRAINT, ROOT_REORDER_TOUCH_CONSTRAINT, typeFilteredCollisionDetection, verticalAxisOnly } from '../../utils/dndConfig';
 import { getFolderNote, openFolderNoteFile } from '../../utils/folderNotes';
 import { resolveFolderNoteClickOpenContext } from '../../utils/keyboardOpenContext';
 import type { ListPaneItem } from '../../types/virtualization';
@@ -52,6 +56,7 @@ interface ListPaneVirtualContentProps {
     settings: NotebookNavigatorSettings;
     pinnedSectionIcon: string;
     selectionType: NavigationItemType | null;
+    selectedTag: string | null;
     sortOption?: SortOption;
     searchHighlightQuery?: string;
     isFolderNavigation: boolean;
@@ -86,6 +91,72 @@ function getDateGroupLabel(listItems: ListPaneItem[], index: number): string | n
     return null;
 }
 
+interface SortablePinnedFileRowProps {
+    item: ListPaneItem;
+    isSelected: boolean;
+    hasSelectedAbove: boolean;
+    hasSelectedBelow: boolean;
+    onFileClick: (file: TFile, fileIndex: number | undefined, event: React.MouseEvent) => void;
+    selectionType: NavigationItemType | null;
+    sortOption?: SortOption;
+    searchHighlightQuery?: string;
+    onModifySearchWithTag: (tag: string, operator: InclusionOperator) => void;
+    onModifySearchWithProperty: (key: string, value: string | null, operator: InclusionOperator) => void;
+    localDayReference: Date | null;
+    fileIconSize: number;
+    visibleListPropertyKeys: ReadonlySet<string>;
+    visibleNavigationPropertyKeys: ReadonlySet<string>;
+    dateGroup: string | null;
+}
+
+function SortablePinnedFileRow(props: SortablePinnedFileRowProps) {
+    const { item } = props;
+    const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
+        id: item.key,
+        disabled: item.type !== ListPaneItemType.FILE || item.isPinned !== true
+    });
+
+    if (item.type !== ListPaneItemType.FILE || !(item.data instanceof TFile)) {
+        return null;
+    }
+
+    const dragStyle = transform ? { transform: CSS.Transform.toString(transform), transition } : undefined;
+
+    return (
+        <div ref={setNodeRef} style={dragStyle} className="nn-pinned-sortable-row">
+            <FileItem
+                file={item.data}
+                isSelected={props.isSelected}
+                hasSelectedAbove={props.hasSelectedAbove}
+                hasSelectedBelow={props.hasSelectedBelow}
+                onFileClick={props.onFileClick}
+                fileIndex={item.fileIndex}
+                selectionType={props.selectionType}
+                dateGroup={props.dateGroup}
+                sortOption={props.sortOption}
+                parentFolder={item.parentFolder}
+                isPinned={item.isPinned}
+                searchQuery={props.searchHighlightQuery}
+                searchMeta={item.searchMeta}
+                isHidden={Boolean(item.isHidden)}
+                onModifySearchWithTag={props.onModifySearchWithTag}
+                onModifySearchWithProperty={props.onModifySearchWithProperty}
+                localDayReference={props.localDayReference}
+                fileIconSize={props.fileIconSize}
+                visiblePropertyKeys={props.visibleListPropertyKeys}
+                visibleNavigationPropertyKeys={props.visibleNavigationPropertyKeys}
+                disableNativeDrag={true}
+            />
+            <div
+                className="nn-pinned-row-drag-proxy"
+                {...attributes}
+                {...listeners}
+                aria-label="Reorder pinned note"
+            />
+        </div>
+    );
+}
+
 export function ListPaneVirtualContent({
     listItems,
     rowVirtualizer,
@@ -98,6 +169,7 @@ export function ListPaneVirtualContent({
     settings,
     pinnedSectionIcon,
     selectionType,
+    selectedTag,
     sortOption,
     searchHighlightQuery,
     isFolderNavigation,
@@ -113,6 +185,11 @@ export function ListPaneVirtualContent({
     onNavigateToFolder
 }: ListPaneVirtualContentProps) {
     const { app, commandQueue, isMobile } = useServices();
+    const metadataService = useMetadataService();
+    const sensors = useSensors(
+        useSensor(MouseSensor, { activationConstraint: ROOT_REORDER_MOUSE_CONSTRAINT }),
+        useSensor(TouchSensor, { activationConstraint: ROOT_REORDER_TOUCH_CONSTRAINT })
+    );
 
     const folderGroupHeaderTargets = useMemo(() => {
         const targets = new Map<string, FolderGroupHeaderTarget>();
@@ -213,6 +290,44 @@ export function ListPaneVirtualContent({
         [app, commandQueue, onNavigateToFolder]
     );
 
+    const pinnedSortableIds = useMemo(() => {
+        if (selectionType !== ItemType.TAG || !selectedTag) {
+            return [];
+        }
+
+        return listItems
+            .filter(item => item.type === ListPaneItemType.FILE && item.isPinned === true)
+            .map(item => item.key);
+    }, [listItems, selectedTag, selectionType]);
+
+    const handlePinnedDragEnd = useCallback(
+        (event: DragEndEvent) => {
+            if (!selectedTag) {
+                return;
+            }
+
+            const activeId = String(event.active.id);
+            const overId = event.over ? String(event.over.id) : null;
+            if (!overId || activeId === overId) {
+                return;
+            }
+
+            const currentPinnedPaths = listItems
+                .filter(item => item.type === ListPaneItemType.FILE && item.isPinned === true)
+                .map(item => item.key);
+            const oldIndex = currentPinnedPaths.indexOf(activeId);
+            const newIndex = currentPinnedPaths.indexOf(overId);
+            if (oldIndex === -1 || newIndex === -1) {
+                return;
+            }
+
+            runAsyncAction(async () => {
+                await metadataService.reorderPinnedInTagView(selectedTag, arrayMove(currentPinnedPaths, oldIndex, newIndex));
+            });
+        },
+        [listItems, metadataService, selectedTag]
+    );
+
     return (
         <div
             ref={scrollContainerRefCallback}
@@ -235,12 +350,19 @@ export function ListPaneVirtualContent({
                         <div className="nn-empty-message">{strings.listPane.emptyStateNoNotes}</div>
                     </div>
                 ) : listItems.length > 0 ? (
-                    <div
-                        className="nn-virtual-container"
-                        style={{
-                            height: `${rowVirtualizer.getTotalSize()}px`
-                        }}
+                    <DndContext
+                        sensors={pinnedSortableIds.length > 0 ? sensors : undefined}
+                        collisionDetection={typeFilteredCollisionDetection}
+                        modifiers={[verticalAxisOnly]}
+                        onDragEnd={handlePinnedDragEnd}
                     >
+                        <SortableContext items={pinnedSortableIds} strategy={verticalListSortingStrategy}>
+                            <div
+                                className="nn-virtual-container"
+                                style={{
+                                    height: `${rowVirtualizer.getTotalSize()}px`
+                                }}
+                            >
                         {rowVirtualizer.getVirtualItems().map(virtualItem => {
                             const item = getItemAt(listItems, virtualItem.index);
                             if (!item) {
@@ -349,34 +471,56 @@ export function ListPaneVirtualContent({
                                     ) : item.type === ListPaneItemType.BOTTOM_SPACER ? (
                                         <div className="nn-list-bottom-spacer" />
                                     ) : item.type === ListPaneItemType.FILE && item.data instanceof TFile ? (
-                                        <FileItem
-                                            key={item.key}
-                                            file={item.data}
-                                            isSelected={isSelected}
-                                            hasSelectedAbove={hasSelectedAbove}
-                                            hasSelectedBelow={hasSelectedBelow}
-                                            onFileClick={onFileClick}
-                                            fileIndex={item.fileIndex}
-                                            selectionType={selectionType}
-                                            dateGroup={dateGroup}
-                                            sortOption={sortOption}
-                                            parentFolder={item.parentFolder}
-                                            isPinned={item.isPinned}
-                                            searchQuery={searchHighlightQuery}
-                                            searchMeta={item.searchMeta}
-                                            isHidden={Boolean(item.isHidden)}
-                                            onModifySearchWithTag={onModifySearchWithTag}
-                                            onModifySearchWithProperty={onModifySearchWithProperty}
-                                            localDayReference={localDayReference}
-                                            fileIconSize={fileIconSize}
-                                            visiblePropertyKeys={visibleListPropertyKeys}
-                                            visibleNavigationPropertyKeys={visibleNavigationPropertyKeys}
-                                        />
+                                        item.isPinned && selectionType === ItemType.TAG && selectedTag ? (
+                                            <SortablePinnedFileRow
+                                                item={item}
+                                                isSelected={isSelected}
+                                                hasSelectedAbove={hasSelectedAbove}
+                                                hasSelectedBelow={hasSelectedBelow}
+                                                onFileClick={onFileClick}
+                                                selectionType={selectionType}
+                                                sortOption={sortOption}
+                                                searchHighlightQuery={searchHighlightQuery}
+                                                onModifySearchWithTag={onModifySearchWithTag}
+                                                onModifySearchWithProperty={onModifySearchWithProperty}
+                                                localDayReference={localDayReference}
+                                                fileIconSize={fileIconSize}
+                                                visibleListPropertyKeys={visibleListPropertyKeys}
+                                                visibleNavigationPropertyKeys={visibleNavigationPropertyKeys}
+                                                dateGroup={dateGroup}
+                                            />
+                                        ) : (
+                                            <FileItem
+                                                key={item.key}
+                                                file={item.data}
+                                                isSelected={isSelected}
+                                                hasSelectedAbove={hasSelectedAbove}
+                                                hasSelectedBelow={hasSelectedBelow}
+                                                onFileClick={onFileClick}
+                                                fileIndex={item.fileIndex}
+                                                selectionType={selectionType}
+                                                dateGroup={dateGroup}
+                                                sortOption={sortOption}
+                                                parentFolder={item.parentFolder}
+                                                isPinned={item.isPinned}
+                                                searchQuery={searchHighlightQuery}
+                                                searchMeta={item.searchMeta}
+                                                isHidden={Boolean(item.isHidden)}
+                                                onModifySearchWithTag={onModifySearchWithTag}
+                                                onModifySearchWithProperty={onModifySearchWithProperty}
+                                                localDayReference={localDayReference}
+                                                fileIconSize={fileIconSize}
+                                                visiblePropertyKeys={visibleListPropertyKeys}
+                                                visibleNavigationPropertyKeys={visibleNavigationPropertyKeys}
+                                            />
+                                        )
                                     ) : null}
                                 </div>
                             );
                         })}
-                    </div>
+                            </div>
+                        </SortableContext>
+                    </DndContext>
                 ) : null}
             </div>
         </div>

--- a/src/components/listPane/ListPaneVirtualContent.tsx
+++ b/src/components/listPane/ListPaneVirtualContent.tsx
@@ -112,7 +112,7 @@ interface SortablePinnedFileRowProps {
 
 function SortablePinnedFileRow(props: SortablePinnedFileRowProps) {
     const { item } = props;
-    const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
+    const { attributes, listeners, setNodeRef, transform, transition, isDragging, isSorting } = useSortable({
         id: item.key,
         disabled: item.type !== ListPaneItemType.FILE || item.isPinned !== true
     });
@@ -124,7 +124,14 @@ function SortablePinnedFileRow(props: SortablePinnedFileRowProps) {
     const dragStyle = transform ? { transform: CSS.Transform.toString(transform), transition } : undefined;
 
     return (
-        <div ref={setNodeRef} style={dragStyle} className="nn-pinned-sortable-row">
+        <div
+            ref={setNodeRef}
+            style={dragStyle}
+            className={`nn-pinned-sortable-row${isDragging || isSorting ? ' nn-pinned-sortable-row--dragging' : ''}`}
+            {...attributes}
+            {...listeners}
+            aria-label="Reorder pinned note"
+        >
             <FileItem
                 file={item.data}
                 isSelected={props.isSelected}
@@ -147,12 +154,6 @@ function SortablePinnedFileRow(props: SortablePinnedFileRowProps) {
                 visiblePropertyKeys={props.visibleListPropertyKeys}
                 visibleNavigationPropertyKeys={props.visibleNavigationPropertyKeys}
                 disableNativeDrag={true}
-            />
-            <div
-                className="nn-pinned-row-drag-proxy"
-                {...attributes}
-                {...listeners}
-                aria-label="Reorder pinned note"
             />
         </div>
     );

--- a/src/components/listPane/ListPaneVirtualContent.tsx
+++ b/src/components/listPane/ListPaneVirtualContent.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { DndContext, MouseSensor, TouchSensor, type DragEndEvent, useSensor, useSensors } from '@dnd-kit/core';
 import { SortableContext, arrayMove, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
@@ -27,6 +27,7 @@ import { strings } from '../../i18n';
 import { ItemType, ListPaneItemType, PINNED_SECTION_HEADER_KEY, type NavigationItemType } from '../../types';
 import { runAsyncAction } from '../../utils/async';
 import { ROOT_REORDER_MOUSE_CONSTRAINT, ROOT_REORDER_TOUCH_CONSTRAINT, typeFilteredCollisionDetection, verticalAxisOnly } from '../../utils/dndConfig';
+import { areStringArraysEqual } from '../../utils/arrayUtils';
 import { getFolderNote, openFolderNoteFile } from '../../utils/folderNotes';
 import { resolveFolderNoteClickOpenContext } from '../../utils/keyboardOpenContext';
 import type { ListPaneItem } from '../../types/virtualization';
@@ -186,6 +187,7 @@ export function ListPaneVirtualContent({
 }: ListPaneVirtualContentProps) {
     const { app, commandQueue, isMobile } = useServices();
     const metadataService = useMetadataService();
+    const [localPinnedOrder, setLocalPinnedOrder] = useState<string[] | null>(null);
     const sensors = useSensors(
         useSensor(MouseSensor, { activationConstraint: ROOT_REORDER_MOUSE_CONSTRAINT }),
         useSensor(TouchSensor, { activationConstraint: ROOT_REORDER_TOUCH_CONSTRAINT })
@@ -295,10 +297,73 @@ export function ListPaneVirtualContent({
             return [];
         }
 
-        return listItems
+        const persistedPinnedIds = listItems
             .filter(item => item.type === ListPaneItemType.FILE && item.isPinned === true)
             .map(item => item.key);
-    }, [listItems, selectedTag, selectionType]);
+        if (!localPinnedOrder || !areStringArraysEqual(localPinnedOrder, persistedPinnedIds)) {
+            return persistedPinnedIds;
+        }
+
+        return localPinnedOrder;
+    }, [listItems, localPinnedOrder, selectedTag, selectionType]);
+
+    const renderedListItems = useMemo(() => {
+        if (selectionType !== ItemType.TAG || !selectedTag || !localPinnedOrder || localPinnedOrder.length === 0) {
+            return listItems;
+        }
+
+        const pinnedItemsByPath = new Map<string, ListPaneItem>();
+        const reorderedPinnedItems: ListPaneItem[] = [];
+
+        listItems.forEach(item => {
+            if (item.type === ListPaneItemType.FILE && item.isPinned === true) {
+                pinnedItemsByPath.set(item.key, item);
+            }
+        });
+
+        localPinnedOrder.forEach(path => {
+            const item = pinnedItemsByPath.get(path);
+            if (!item) {
+                return;
+            }
+
+            reorderedPinnedItems.push(item);
+            pinnedItemsByPath.delete(path);
+        });
+
+        pinnedItemsByPath.forEach(item => {
+            reorderedPinnedItems.push(item);
+        });
+
+        let pinnedIndex = 0;
+        return listItems.map(item => {
+            if (item.type === ListPaneItemType.FILE && item.isPinned === true) {
+                const nextItem = reorderedPinnedItems[pinnedIndex];
+                pinnedIndex += 1;
+                return nextItem ?? item;
+            }
+
+            return item;
+        });
+    }, [listItems, localPinnedOrder, selectedTag, selectionType]);
+
+    useEffect(() => {
+        if (!localPinnedOrder) {
+            return;
+        }
+
+        const persistedPinnedIds = listItems
+            .filter(item => item.type === ListPaneItemType.FILE && item.isPinned === true)
+            .map(item => item.key);
+
+        if (areStringArraysEqual(localPinnedOrder, persistedPinnedIds)) {
+            setLocalPinnedOrder(null);
+        }
+    }, [listItems, localPinnedOrder]);
+
+    useEffect(() => {
+        setLocalPinnedOrder(null);
+    }, [selectedTag]);
 
     const handlePinnedDragEnd = useCallback(
         (event: DragEndEvent) => {
@@ -312,20 +377,25 @@ export function ListPaneVirtualContent({
                 return;
             }
 
-            const currentPinnedPaths = listItems
-                .filter(item => item.type === ListPaneItemType.FILE && item.isPinned === true)
-                .map(item => item.key);
+            const currentPinnedPaths = pinnedSortableIds;
             const oldIndex = currentPinnedPaths.indexOf(activeId);
             const newIndex = currentPinnedPaths.indexOf(overId);
             if (oldIndex === -1 || newIndex === -1) {
                 return;
             }
 
+            const nextPinnedPaths = arrayMove(currentPinnedPaths, oldIndex, newIndex);
+            setLocalPinnedOrder(nextPinnedPaths);
+
             runAsyncAction(async () => {
-                await metadataService.reorderPinnedInTagView(selectedTag, arrayMove(currentPinnedPaths, oldIndex, newIndex));
+                try {
+                    await metadataService.reorderPinnedInTagView(selectedTag, nextPinnedPaths);
+                } catch {
+                    setLocalPinnedOrder(null);
+                }
             });
         },
-        [listItems, metadataService, selectedTag]
+        [metadataService, pinnedSortableIds, selectedTag]
     );
 
     return (
@@ -349,7 +419,7 @@ export function ListPaneVirtualContent({
                     <div className="nn-empty-state">
                         <div className="nn-empty-message">{strings.listPane.emptyStateNoNotes}</div>
                     </div>
-                ) : listItems.length > 0 ? (
+                ) : renderedListItems.length > 0 ? (
                     <DndContext
                         sensors={pinnedSortableIds.length > 0 ? sensors : undefined}
                         collisionDetection={typeFilteredCollisionDetection}
@@ -364,7 +434,7 @@ export function ListPaneVirtualContent({
                                 }}
                             >
                         {rowVirtualizer.getVirtualItems().map(virtualItem => {
-                            const item = getItemAt(listItems, virtualItem.index);
+                            const item = getItemAt(renderedListItems, virtualItem.index);
                             if (!item) {
                                 return null;
                             }
@@ -377,11 +447,11 @@ export function ListPaneVirtualContent({
                                 }
                             }
 
-                            const nextItem = getItemAt(listItems, virtualItem.index + 1);
-                            const previousItem = getItemAt(listItems, virtualItem.index - 1);
+                            const nextItem = getItemAt(renderedListItems, virtualItem.index + 1);
+                            const previousItem = getItemAt(renderedListItems, virtualItem.index - 1);
                             const isLastFile =
                                 item.type === ListPaneItemType.FILE &&
-                                (virtualItem.index === listItems.length - 1 ||
+                                (virtualItem.index === renderedListItems.length - 1 ||
                                     (nextItem &&
                                         (nextItem.type === ListPaneItemType.HEADER ||
                                             nextItem.type === ListPaneItemType.TOP_SPACER ||
@@ -405,7 +475,8 @@ export function ListPaneVirtualContent({
                             const folderGroupHeaderTarget =
                                 headerFolderPath !== null ? (folderGroupHeaderTargets.get(headerFolderPath) ?? null) : null;
                             const isClickableFolderGroupHeader = Boolean(folderGroupHeaderTarget) && !isPinnedHeader;
-                            const dateGroup = item.type === ListPaneItemType.FILE ? getDateGroupLabel(listItems, virtualItem.index) : null;
+                            const dateGroup =
+                                item.type === ListPaneItemType.FILE ? getDateGroupLabel(renderedListItems, virtualItem.index) : null;
 
                             const hideSeparator =
                                 item.type === ListPaneItemType.FILE &&

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -38,7 +38,7 @@ import {
     cloneShortcuts,
     getActiveVaultProfile
 } from '../utils/vaultProfiles';
-import { clonePinnedNotesRecord, isStringRecordValue, sanitizeRecord } from '../utils/recordUtils';
+import { clonePinnedNotesRecord, clonePinnedTagOrderByTagRecord, isStringRecordValue, sanitizeRecord } from '../utils/recordUtils';
 import { areStringArraysEqual } from '../utils/arrayUtils';
 import type { FolderAppearance } from '../hooks/useListPaneAppearance';
 import { buildFileNameIconNeedles, type FileNameIconNeedle } from '../utils/fileIconUtils';
@@ -254,7 +254,8 @@ export function SettingsProvider({ children, plugin }: SettingsProviderProps) {
             folderAppearances: cloneAppearanceMap(plugin.settings.folderAppearances),
             tagAppearances: cloneAppearanceMap(plugin.settings.tagAppearances),
             propertyAppearances: cloneAppearanceMap(plugin.settings.propertyAppearances),
-            pinnedNotes: clonePinnedNotesRecord(plugin.settings.pinnedNotes)
+            pinnedNotes: clonePinnedNotesRecord(plugin.settings.pinnedNotes),
+            pinnedTagOrderByTag: clonePinnedTagOrderByTagRecord(plugin.settings.pinnedTagOrderByTag)
         };
         // Deep copy vault profiles to prevent mutations from affecting the original settings
         if (Array.isArray(plugin.settings.vaultProfiles)) {

--- a/src/hooks/listPaneData/listItems.ts
+++ b/src/hooks/listPaneData/listItems.ts
@@ -28,6 +28,7 @@ import { resolveListGrouping } from '../../utils/listGrouping';
 import { partitionPinnedFiles } from '../../utils/fileFinder';
 import { createHiddenTagVisibility } from '../../utils/tagPrefixMatcher';
 import { getCachedFileTags } from '../../utils/tagUtils';
+import { normalizeTagPath } from '../../utils/tagUtils';
 import { DateUtils } from '../../utils/dateUtils';
 import type { SearchResultMeta } from '../../types/search';
 import type { IndexedDBStorage } from '../../storage/IndexedDBStorage';
@@ -40,6 +41,7 @@ export interface ListPaneConfig {
     folderTreeSortOverrides: NotebookNavigatorSettings['folderTreeSortOverrides'];
     noteGrouping: NotebookNavigatorSettings['noteGrouping'];
     pinnedNotes: NotebookNavigatorSettings['pinnedNotes'];
+    pinnedTagOrderByTag: NotebookNavigatorSettings['pinnedTagOrderByTag'];
     propertyAppearances: NotebookNavigatorSettings['propertyAppearances'];
     showFileTags: boolean;
     showPinnedGroupHeader: boolean;
@@ -110,7 +112,27 @@ export function buildListItems({
                 ? { restrictToPropertyNodeId: selectedProperty, db }
                 : undefined
         : undefined;
-    const { pinnedFiles, unpinnedFiles } = partitionPinnedFiles(files, listConfig.pinnedNotes, contextFilter, pinnedDisplayScope);
+    const { pinnedFiles, unpinnedFiles } =
+        selectionType === ItemType.TAG && selectedTag
+            ? (() => {
+                  const normalizedTag = normalizeTagPath(selectedTag);
+                  if (!normalizedTag) {
+                      return { pinnedFiles: [] as TFile[], unpinnedFiles: files };
+                  }
+
+                  const filesByPath = new Map(files.map(file => [file.path, file] as const));
+                  const pinnedPaths = listConfig.pinnedTagOrderByTag[normalizedTag] ?? [];
+                  const pinnedFiles = pinnedPaths
+                      .map(path => filesByPath.get(path) ?? null)
+                      .filter((file): file is TFile => file !== null);
+                  const pinnedSet = new Set(pinnedFiles.map(file => file.path));
+
+                  return {
+                      pinnedFiles,
+                      unpinnedFiles: files.filter(file => !pinnedSet.has(file.path))
+                  };
+              })()
+            : partitionPinnedFiles(files, listConfig.pinnedNotes, contextFilter, pinnedDisplayScope);
     const shouldDetectTags = listConfig.showTags && listConfig.showFileTags;
     const hiddenTagVisibility = shouldDetectTags ? createHiddenTagVisibility(hiddenTags, showHiddenItems) : null;
     const fileHasTags = shouldDetectTags

--- a/src/hooks/useListPaneData.ts
+++ b/src/hooks/useListPaneData.ts
@@ -172,7 +172,8 @@ export function useListPaneData({
             tagAppearances: settings.tagAppearances,
             propertyAppearances: settings.propertyAppearances,
             folderSortOrder: settings.folderSortOrder,
-            folderTreeSortOverrides: settings.folderTreeSortOverrides
+            folderTreeSortOverrides: settings.folderTreeSortOverrides,
+            pinnedTagOrderByTag: settings.pinnedTagOrderByTag
         }),
         [
             settings.filterPinnedByFolder,
@@ -181,6 +182,7 @@ export function useListPaneData({
             settings.folderTreeSortOverrides,
             settings.noteGrouping,
             settings.pinnedNotes,
+            settings.pinnedTagOrderByTag,
             settings.showFileTags,
             settings.showPinnedGroupHeader,
             settings.showTags,

--- a/src/services/MetadataService.ts
+++ b/src/services/MetadataService.ts
@@ -409,12 +409,28 @@ export class MetadataService {
         return this.fileService.pinNotes(filePaths, context);
     }
 
+    async togglePinnedInTagView(filePath: string, tagPath: string): Promise<void> {
+        return this.fileService.togglePinnedInTagView(filePath, tagPath);
+    }
+
     isFilePinned(filePath: string, context?: NavigatorContext): boolean {
         return this.fileService.isPinned(filePath, context);
     }
 
+    isFilePinnedInTagView(filePath: string, tagPath: string): boolean {
+        return this.fileService.isPinnedInTagView(filePath, tagPath);
+    }
+
     getPinnedNotes(context?: NavigatorContext): string[] {
         return this.fileService.getPinnedNotes(context);
+    }
+
+    getPinnedTagOrder(tagPath: string): string[] {
+        return this.fileService.getPinnedTagOrder(tagPath);
+    }
+
+    async reorderPinnedInTagView(tagPath: string, orderedPaths: string[]): Promise<void> {
+        return this.fileService.reorderPinnedInTagView(tagPath, orderedPaths);
     }
 
     async setFileIcon(filePath: string, iconId: string): Promise<void> {

--- a/src/services/MetadataService.ts
+++ b/src/services/MetadataService.ts
@@ -272,7 +272,8 @@ export class MetadataService {
      */
     async handleTagRename(oldPath: string, newPath: string, preserveExisting = false): Promise<void> {
         await this.tagService.handleTagRename(oldPath, newPath, preserveExisting, settings =>
-            this.navigationSeparatorService.applyTagRename(settings, oldPath, newPath, preserveExisting)
+            this.navigationSeparatorService.applyTagRename(settings, oldPath, newPath, preserveExisting) ||
+            this.fileService.applyTagRenameToPinnedTagOrder(settings, oldPath, newPath, preserveExisting)
         );
     }
 
@@ -280,7 +281,12 @@ export class MetadataService {
      * Removes all metadata associated with a tag and its descendants
      */
     async handleTagDelete(tagPath: string): Promise<void> {
-        await this.tagService.handleTagDelete(tagPath, settings => this.navigationSeparatorService.applyTagDelete(settings, tagPath));
+        await this.tagService.handleTagDelete(
+            tagPath,
+            settings =>
+                this.navigationSeparatorService.applyTagDelete(settings, tagPath) ||
+                this.fileService.applyTagDeleteToPinnedTagOrder(settings, tagPath)
+        );
     }
 
     async setTagSortOverride(tagPath: string, sortOption: SortOption): Promise<void> {

--- a/src/services/metadata/FileMetadataService.ts
+++ b/src/services/metadata/FileMetadataService.ts
@@ -24,7 +24,8 @@ import { isNoteShortcut } from '../../types/shortcuts';
 import type { NotebookNavigatorSettings } from '../../settings';
 import { getDBInstance } from '../../storage/fileOperations';
 import { deserializeIconFromFrontmatterCompat, normalizeCanonicalIconId, serializeIconForFrontmatter } from '../../utils/iconizeFormat';
-import { normalizePinnedNoteContext } from '../../utils/recordUtils';
+import { normalizePinnedNoteContext, normalizePinnedPathOrder } from '../../utils/recordUtils';
+import { normalizeTagPath } from '../../utils/tagUtils';
 
 /**
  * Service for managing file-specific metadata operations
@@ -45,6 +46,121 @@ export interface FileMetadataMigrationResult {
 
 export class FileMetadataService extends BaseMetadataService {
     private static readonly VAULT_ICON_PROVIDER_ID = 'vault';
+
+    private getNormalizedTagPinKey(tagPath: string): string | null {
+        return normalizeTagPath(tagPath);
+    }
+
+    private getPinnedTagOrderStore(settings: NotebookNavigatorSettings): NotebookNavigatorSettings['pinnedTagOrderByTag'] {
+        if (!settings.pinnedTagOrderByTag) {
+            settings.pinnedTagOrderByTag = {};
+        }
+
+        return settings.pinnedTagOrderByTag;
+    }
+
+    private setPinnedTagOrder(settings: NotebookNavigatorSettings, tagPath: string, orderedPaths: readonly string[]): boolean {
+        const normalizedTag = this.getNormalizedTagPinKey(tagPath);
+        if (!normalizedTag) {
+            return false;
+        }
+
+        const store = this.getPinnedTagOrderStore(settings);
+        const normalizedPaths = normalizePinnedPathOrder(orderedPaths);
+        const existing = normalizePinnedPathOrder(store[normalizedTag]);
+
+        if (normalizedPaths.length === 0) {
+            if (existing.length === 0) {
+                return false;
+            }
+
+            delete store[normalizedTag];
+            return true;
+        }
+
+        if (existing.length === normalizedPaths.length && existing.every((path, index) => path === normalizedPaths[index])) {
+            return false;
+        }
+
+        store[normalizedTag] = normalizedPaths;
+        return true;
+    }
+
+    private removePinnedTagPathAcrossAllTags(settings: NotebookNavigatorSettings, filePath: string): boolean {
+        const store = this.getPinnedTagOrderStore(settings);
+        let changed = false;
+
+        Object.entries(store).forEach(([tagPath, paths]) => {
+            const nextPaths = normalizePinnedPathOrder(paths).filter(path => path !== filePath);
+            changed = this.setPinnedTagOrder(settings, tagPath, nextPaths) || changed;
+        });
+
+        return changed;
+    }
+
+    private renamePinnedTagPathAcrossAllTags(settings: NotebookNavigatorSettings, oldPath: string, newPath: string): boolean {
+        const store = this.getPinnedTagOrderStore(settings);
+        let changed = false;
+
+        Object.entries(store).forEach(([tagPath, paths]) => {
+            if (!normalizePinnedPathOrder(paths).includes(oldPath)) {
+                return;
+            }
+
+            const nextPaths = normalizePinnedPathOrder(paths).map(path => (path === oldPath ? newPath : path));
+            changed = this.setPinnedTagOrder(settings, tagPath, nextPaths) || changed;
+        });
+
+        return changed;
+    }
+
+    isPinnedInTagView(filePath: string, tagPath: string): boolean {
+        const normalizedTag = this.getNormalizedTagPinKey(tagPath);
+        if (!normalizedTag) {
+            return false;
+        }
+
+        return normalizePinnedPathOrder(this.settingsProvider.settings.pinnedTagOrderByTag?.[normalizedTag]).includes(filePath);
+    }
+
+    getPinnedTagOrder(tagPath: string): string[] {
+        const normalizedTag = this.getNormalizedTagPinKey(tagPath);
+        if (!normalizedTag) {
+            return [];
+        }
+
+        return normalizePinnedPathOrder(this.settingsProvider.settings.pinnedTagOrderByTag?.[normalizedTag]);
+    }
+
+    async togglePinnedInTagView(filePath: string, tagPath: string): Promise<void> {
+        const normalizedTag = this.getNormalizedTagPinKey(tagPath);
+        if (!normalizedTag) {
+            return;
+        }
+
+        await this.saveAndUpdate(settings => {
+            const currentPaths = normalizePinnedPathOrder(this.getPinnedTagOrderStore(settings)[normalizedTag]);
+            const isPinned = currentPaths.includes(filePath);
+            if (isPinned) {
+                return this.setPinnedTagOrder(
+                    settings,
+                    normalizedTag,
+                    currentPaths.filter(path => path !== filePath)
+                );
+            }
+
+            return this.setPinnedTagOrder(settings, normalizedTag, [...currentPaths, filePath]);
+        });
+    }
+
+    async reorderPinnedInTagView(tagPath: string, orderedPaths: string[]): Promise<void> {
+        const normalizedTag = this.getNormalizedTagPinKey(tagPath);
+        if (!normalizedTag) {
+            return;
+        }
+
+        await this.saveAndUpdate(settings => this.setPinnedTagOrder(settings, normalizedTag, orderedPaths));
+    }
 
     /**
      * Gets a TFile instance from a file path
@@ -479,17 +595,22 @@ export class FileMetadataService extends BaseMetadataService {
      */
     async handleFileDelete(filePath: string): Promise<void> {
         await this.saveAndUpdate(settings => {
+            let changed = this.removePinnedTagPathAcrossAllTags(settings, filePath);
             if (settings.pinnedNotes?.[filePath]) {
                 delete settings.pinnedNotes[filePath];
+                changed = true;
             }
             if (settings.fileIcons?.[filePath]) {
                 delete settings.fileIcons[filePath];
+                changed = true;
             }
             if (settings.fileColors?.[filePath]) {
                 delete settings.fileColors[filePath];
+                changed = true;
             }
             if (settings.fileBackgroundColors?.[filePath]) {
                 delete settings.fileBackgroundColors[filePath];
+                changed = true;
             }
 
             this.updateShortcuts(settings, shortcut => {
@@ -498,6 +619,7 @@ export class FileMetadataService extends BaseMetadataService {
                 }
                 return shortcut.path === filePath ? null : undefined;
             });
+            return changed;
         });
     }
 
@@ -513,6 +635,7 @@ export class FileMetadataService extends BaseMetadataService {
 
         await this.saveAndUpdate(settings => {
             let changed = false;
+            changed = this.renamePinnedTagPathAcrossAllTags(settings, oldPath, newPath) || changed;
             if (settings.pinnedNotes?.[oldPath]) {
                 // Save contexts and delete old entry
                 const contexts = settings.pinnedNotes[oldPath];
@@ -864,6 +987,28 @@ export class FileMetadataService extends BaseMetadataService {
                 }
 
                 hasChanges = true;
+            }
+        }
+
+        const pinnedTagOrderByTag = targetSettings.pinnedTagOrderByTag;
+        if (pinnedTagOrderByTag && Object.keys(pinnedTagOrderByTag).length > 0) {
+            const applyTagCleanup = (settings: NotebookNavigatorSettings) => {
+                let changed = false;
+                Object.entries(settings.pinnedTagOrderByTag ?? {}).forEach(([tagPath, paths]) => {
+                    const nextPaths = normalizePinnedPathOrder(paths).filter(path => validators.vaultFiles.has(path));
+                    changed = this.setPinnedTagOrder(settings, tagPath, nextPaths) || changed;
+                });
+                return changed;
+            };
+
+            if (targetSettings === this.settingsProvider.settings) {
+                const changed = applyTagCleanup(this.settingsProvider.settings);
+                if (changed) {
+                    await this.settingsProvider.saveSettingsAndUpdate();
+                }
+                hasChanges = hasChanges || changed;
+            } else {
+                hasChanges = applyTagCleanup(targetSettings) || hasChanges;
             }
         }
 

--- a/src/services/metadata/FileMetadataService.ts
+++ b/src/services/metadata/FileMetadataService.ts
@@ -114,6 +114,26 @@ export class FileMetadataService extends BaseMetadataService {
         return changed;
     }
 
+    private removePinnedTagOrdersForTag(settings: NotebookNavigatorSettings, tagPath: string): boolean {
+        const normalizedTag = this.getNormalizedTagPinKey(tagPath);
+        if (!normalizedTag) {
+            return false;
+        }
+
+        const store = this.getPinnedTagOrderStore(settings);
+        const prefix = `${normalizedTag}/`;
+        let changed = false;
+
+        Object.keys(store).forEach(path => {
+            if (path === normalizedTag || path.startsWith(prefix)) {
+                delete store[path];
+                changed = true;
+            }
+        });
+
+        return changed;
+    }
+
     isPinnedInTagView(filePath: string, tagPath: string): boolean {
         const normalizedTag = this.getNormalizedTagPinKey(tagPath);
         if (!normalizedTag) {
@@ -160,6 +180,25 @@ export class FileMetadataService extends BaseMetadataService {
         }
 
         await this.saveAndUpdate(settings => this.setPinnedTagOrder(settings, normalizedTag, orderedPaths));
+    }
+
+    applyTagRenameToPinnedTagOrder(
+        settings: NotebookNavigatorSettings,
+        oldPath: string,
+        newPath: string,
+        preserveExisting = false
+    ): boolean {
+        const normalizedOld = this.getNormalizedTagPinKey(oldPath);
+        const normalizedNew = this.getNormalizedTagPinKey(newPath);
+        if (!normalizedOld || !normalizedNew || normalizedOld === normalizedNew) {
+            return false;
+        }
+
+        return this.updateNestedPaths(this.getPinnedTagOrderStore(settings), normalizedOld, normalizedNew, preserveExisting);
+    }
+
+    applyTagDeleteToPinnedTagOrder(settings: NotebookNavigatorSettings, tagPath: string): boolean {
+        return this.removePinnedTagOrdersForTag(settings, tagPath);
     }
 
     /**

--- a/src/services/settings/PluginSettingsController.ts
+++ b/src/services/settings/PluginSettingsController.ts
@@ -70,6 +70,7 @@ import {
 import { getDefaultDateFormat, getDefaultTimeFormat } from '../../i18n';
 import {
     clonePinnedNotesRecord,
+    clonePinnedTagOrderByTagRecord,
     isBooleanRecordValue,
     isPlainObjectRecordValue,
     isStringRecordValue,
@@ -828,6 +829,7 @@ export class PluginSettingsController {
         this.currentSettings.externalIconProviders = sanitizeBooleanMap(this.currentSettings.externalIconProviders);
         this.currentSettings.syncModes = sanitizeSettingsSyncMap(this.currentSettings.syncModes);
         this.currentSettings.pinnedNotes = clonePinnedNotesRecord(this.currentSettings.pinnedNotes);
+        this.currentSettings.pinnedTagOrderByTag = clonePinnedTagOrderByTagRecord(this.currentSettings.pinnedTagOrderByTag);
     }
 
     private normalizeTaskSettings(): void {

--- a/src/settings/defaultSettings.ts
+++ b/src/settings/defaultSettings.ts
@@ -19,7 +19,7 @@
 import { DEFAULT_CUSTOM_COLORS } from '../constants/colorPalette';
 import { getDefaultKeyboardShortcuts } from '../utils/keyboardShortcuts';
 import { FILE_VISIBILITY } from '../utils/fileTypeUtils';
-import { LISTPANE_MEASUREMENTS, NAVPANE_MEASUREMENTS, type PinnedNotes } from '../types';
+import { LISTPANE_MEASUREMENTS, NAVPANE_MEASUREMENTS, type PinnedNotes, type PinnedTagOrderByTag } from '../types';
 import { DEFAULT_UI_SCALE } from '../utils/uiScale';
 import type { FolderAppearance, TagAppearance } from '../hooks/useListPaneAppearance';
 import { SYNC_MODE_SETTING_IDS, type NavRainbowSettings, type NotebookNavigatorSettings, type SettingSyncMode } from './types';
@@ -382,6 +382,7 @@ export const DEFAULT_SETTINGS: NotebookNavigatorSettings = {
     // Runtime state and cached data
     customVaultName: '',
     pinnedNotes: sanitizeRecord<PinnedNotes[string]>(undefined),
+    pinnedTagOrderByTag: sanitizeRecord<PinnedTagOrderByTag[string]>(undefined),
     fileIcons: sanitizeRecord<string>(undefined),
     fileColors: sanitizeRecord<string>(undefined),
     fileBackgroundColors: sanitizeRecord<string>(undefined),

--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -18,7 +18,7 @@
 
 import type { FileVisibility } from '../utils/fileTypeUtils';
 import type { FolderAppearance, TagAppearance } from '../hooks/useListPaneAppearance';
-import type { BackgroundMode, DualPaneOrientation, PinnedNotes } from '../types';
+import type { BackgroundMode, DualPaneOrientation, PinnedNotes, PinnedTagOrderByTag } from '../types';
 import type { FolderNoteCreationPreference } from '../types/folderNote';
 import type { KeyboardShortcutConfig } from '../utils/keyboardShortcuts';
 import type { ShortcutEntry } from '../types/shortcuts';
@@ -530,6 +530,7 @@ export interface NotebookNavigatorSettings {
     // Runtime state and cached data
     customVaultName: string;
     pinnedNotes: PinnedNotes;
+    pinnedTagOrderByTag: PinnedTagOrderByTag;
     fileIcons: Record<string, string>;
     fileColors: Record<string, string>;
     fileBackgroundColors: Record<string, string>;

--- a/src/styles/sections/list-files.css
+++ b/src/styles/sections/list-files.css
@@ -93,6 +93,27 @@
     position: relative; /* For absolute positioning of reveal overlay */
 }
 
+.nn-pinned-sortable-row {
+    position: relative;
+}
+
+.nn-pinned-row-drag-proxy {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    bottom: 8px;
+    width: 16px;
+    border-radius: 10px;
+    cursor: grab;
+    opacity: 0.35;
+    background:
+        radial-gradient(circle, currentColor 1.2px, transparent 1.2px) center 4px / 6px 6px repeat-y;
+}
+
+.nn-pinned-row-drag-proxy:active {
+    cursor: grabbing;
+}
+
 .nn-file.nn-has-custom-background .nn-file-content {
     background-color: var(--nn-file-custom-bg-color);
     border-top-left-radius: var(--nn-file-top-left-radius, min(16px, var(--nn-theme-file-border-radius)));

--- a/src/styles/sections/list-files.css
+++ b/src/styles/sections/list-files.css
@@ -97,20 +97,7 @@
     position: relative;
 }
 
-.nn-pinned-row-drag-proxy {
-    position: absolute;
-    top: 8px;
-    right: 8px;
-    bottom: 8px;
-    width: 16px;
-    border-radius: 10px;
-    cursor: grab;
-    opacity: 0.35;
-    background:
-        radial-gradient(circle, currentColor 1.2px, transparent 1.2px) center 4px / 6px 6px repeat-y;
-}
-
-.nn-pinned-row-drag-proxy:active {
+.nn-pinned-sortable-row--dragging {
     cursor: grabbing;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,6 +111,7 @@ export type NavigatorContext = 'folder' | 'tag' | 'property';
  * Maps file paths to their pinning context states
  */
 export type PinnedNotes = Record<string, Record<NavigatorContext, boolean>>;
+export type PinnedTagOrderByTag = Record<string, string[]>;
 
 /**
  * Enum for navigation pane item types

--- a/src/utils/contextMenu/fileMenuBuilder.ts
+++ b/src/utils/contextMenu/fileMenuBuilder.ts
@@ -332,7 +332,7 @@ export function buildFileMenu(params: FileMenuBuilderParams): void {
         }
 
         const pinContext = getNavigatorPinContext(selectionState.selectionType);
-        addMultipleFilesPinOption(menu, cachedSelectedFiles, metadataService, pinContext);
+        addMultipleFilesPinOption(menu, cachedSelectedFiles, metadataService, pinContext, selectionState.selectedTag ?? null);
 
         menu.addSeparator();
 
@@ -923,9 +923,17 @@ function addMultipleFilesShortcutOption(
 /**
  * Add pin option for multiple files
  */
-function addMultipleFilesPinOption(menu: Menu, selectedFiles: TFile[], metadataService: MetadataService, context: NavigatorContext): void {
-    const anyUnpinned = selectedFiles.some(f => {
-        return !metadataService.isFilePinned(f.path, context);
+function addMultipleFilesPinOption(
+    menu: Menu,
+    selectedFiles: TFile[],
+    metadataService: MetadataService,
+    context: NavigatorContext,
+    selectedTag: string | null
+): void {
+    const anyUnpinned = selectedFiles.some(file => {
+        return context === ItemType.TAG && selectedTag
+            ? !metadataService.isFilePinnedInTagView(file.path, selectedTag)
+            : !metadataService.isFilePinned(file.path, context);
     });
 
     // Check if all files are markdown
@@ -947,13 +955,23 @@ function addMultipleFilesPinOption(menu: Menu, selectedFiles: TFile[], metadataS
                 .setIcon('lucide-pin'),
             async () => {
                 for (const selectedFile of selectedFiles) {
+                    if (context === ItemType.TAG && selectedTag) {
+                        const isPinnedInTag = metadataService.isFilePinnedInTagView(selectedFile.path, selectedTag);
+                        if (anyUnpinned) {
+                            if (!isPinnedInTag) {
+                                await metadataService.togglePinnedInTagView(selectedFile.path, selectedTag);
+                            }
+                        } else if (isPinnedInTag) {
+                            await metadataService.togglePinnedInTagView(selectedFile.path, selectedTag);
+                        }
+                        continue;
+                    }
+
                     if (anyUnpinned) {
-                        // Pin all unpinned files
                         if (!metadataService.isFilePinned(selectedFile.path, context)) {
                             await metadataService.togglePin(selectedFile.path, context);
                         }
                     } else {
-                        // Unpin all files
                         await metadataService.togglePin(selectedFile.path, context);
                     }
                 }

--- a/src/utils/contextMenu/fileMenuBuilder.ts
+++ b/src/utils/contextMenu/fileMenuBuilder.ts
@@ -320,7 +320,7 @@ export function buildFileMenu(params: FileMenuBuilderParams): void {
         }
 
         const pinContext = getNavigatorPinContext(selectionState.selectionType);
-        addSingleFilePinOption(menu, file, metadataService, pinContext);
+        addSingleFilePinOption(menu, file, metadataService, pinContext, selectionState.selectedTag ?? null);
 
         menu.addSeparator();
     }
@@ -839,8 +839,17 @@ function addMultipleFilesOpenOptions(
 /**
  * Add pin option for a single file
  */
-function addSingleFilePinOption(menu: Menu, file: TFile, metadataService: MetadataService, context: NavigatorContext): void {
-    const isPinned = metadataService.isFilePinned(file.path, context);
+function addSingleFilePinOption(
+    menu: Menu,
+    file: TFile,
+    metadataService: MetadataService,
+    context: NavigatorContext,
+    selectedTag: string | null
+): void {
+    const isPinned =
+        context === ItemType.TAG && selectedTag
+            ? metadataService.isFilePinnedInTagView(file.path, selectedTag)
+            : metadataService.isFilePinned(file.path, context);
 
     menu.addItem((item: MenuItem) => {
         setAsyncOnClick(
@@ -857,6 +866,11 @@ function addSingleFilePinOption(menu: Menu, file: TFile, metadataService: Metada
                 .setIcon('lucide-pin'),
             async () => {
                 if (!file.parent) return;
+
+                if (context === ItemType.TAG && selectedTag) {
+                    await metadataService.togglePinnedInTagView(file.path, selectedTag);
+                    return;
+                }
 
                 await metadataService.togglePin(file.path, context);
             }

--- a/src/utils/fileFinder.ts
+++ b/src/utils/fileFinder.ts
@@ -684,18 +684,7 @@ export function getFilesForTag(
     const sortOption = getEffectiveSortOption(settings, 'tag', null, tag);
     sortNavigationFiles(filteredFiles, settings, app, sortOption);
 
-    const pinnedDisplayScope = settings.filterPinnedByFolder
-        ? {
-              restrictToTagPath:
-                  tag === TAGGED_TAG_ID || tag === UNTAGGED_TAG_ID
-                      ? tag
-                      : (tagTreeService?.findTagNode(tag)?.path ?? normalizeTagPathValue(tag)),
-              app,
-              db
-          }
-        : undefined;
-
-    return applyPinnedOrdering(filteredFiles, settings, 'tag', pinnedDisplayScope);
+    return filteredFiles;
 }
 
 /**

--- a/src/utils/recordUtils.ts
+++ b/src/utils/recordUtils.ts
@@ -126,6 +126,49 @@ export function clonePinnedNotesRecord(value: unknown): Record<string, PinnedNot
     return cloned;
 }
 
+export function normalizePinnedPathOrder(value: unknown): string[] {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+
+    const seen = new Set<string>();
+    const normalized: string[] = [];
+
+    value.forEach(entry => {
+        if (typeof entry !== 'string') {
+            return;
+        }
+
+        const path = entry.trim();
+        if (path.length === 0 || seen.has(path)) {
+            return;
+        }
+
+        seen.add(path);
+        normalized.push(path);
+    });
+
+    return normalized;
+}
+
+export function clonePinnedTagOrderByTagRecord(value: unknown): Record<string, string[]> {
+    const cloned = sanitizeRecord<string[]>(undefined);
+    if (!isPlainObjectRecordValue(value)) {
+        return cloned;
+    }
+
+    Object.entries(value).forEach(([tagPath, paths]) => {
+        const normalizedPaths = normalizePinnedPathOrder(paths);
+        if (normalizedPaths.length === 0) {
+            return;
+        }
+
+        cloned[tagPath] = normalizedPaths;
+    });
+
+    return cloned;
+}
+
 export function casefold(value: string): string {
     const trimmed = value.trim();
     if (trimmed.length === 0) {

--- a/styles.css
+++ b/styles.css
@@ -3495,20 +3495,7 @@ body {
     position: relative;
 }
 
-.nn-pinned-row-drag-proxy {
-    position: absolute;
-    top: 8px;
-    right: 8px;
-    bottom: 8px;
-    width: 16px;
-    border-radius: 10px;
-    cursor: grab;
-    opacity: 0.35;
-    background:
-        radial-gradient(circle, currentColor 1.2px, transparent 1.2px) center 4px / 6px 6px repeat-y;
-}
-
-.nn-pinned-row-drag-proxy:active {
+.nn-pinned-sortable-row--dragging {
     cursor: grabbing;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -3491,6 +3491,27 @@ body {
     position: relative; /* For absolute positioning of reveal overlay */
 }
 
+.nn-pinned-sortable-row {
+    position: relative;
+}
+
+.nn-pinned-row-drag-proxy {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    bottom: 8px;
+    width: 16px;
+    border-radius: 10px;
+    cursor: grab;
+    opacity: 0.35;
+    background:
+        radial-gradient(circle, currentColor 1.2px, transparent 1.2px) center 4px / 6px 6px repeat-y;
+}
+
+.nn-pinned-row-drag-proxy:active {
+    cursor: grabbing;
+}
+
 .nn-file.nn-has-custom-background .nn-file-content {
     background-color: var(--nn-file-custom-bg-color);
     border-top-left-radius: var(--nn-file-top-left-radius, min(16px, var(--nn-theme-file-border-radius)));

--- a/tests/api/MetadataAPI.test.ts
+++ b/tests/api/MetadataAPI.test.ts
@@ -24,14 +24,17 @@ import { TFolder } from 'obsidian';
 
 describe('MetadataAPI icon normalization', () => {
     let foldersByPath: Map<string, TFolder>;
+    type MetadataServiceMock = {
+        setFolderStyle: ReturnType<typeof vi.fn>;
+        getFolderDisplayData: ReturnType<typeof vi.fn>;
+        isFolderStyleEventBridgeEnabled?: ReturnType<typeof vi.fn>;
+        isFilePinnedInTagView?: ReturnType<typeof vi.fn>;
+        togglePinnedInTagView?: ReturnType<typeof vi.fn>;
+    };
     let plugin: {
         settings: NotebookNavigatorSettings;
         saveSettingsAndUpdate: ReturnType<typeof vi.fn>;
-        metadataService: {
-            setFolderStyle: ReturnType<typeof vi.fn>;
-            getFolderDisplayData: ReturnType<typeof vi.fn>;
-            isFolderStyleEventBridgeEnabled?: ReturnType<typeof vi.fn>;
-        } | null;
+        metadataService: MetadataServiceMock | null;
     };
     let api: ConstructorParameters<typeof MetadataAPI>[0];
     let triggerMock: ReturnType<typeof vi.fn>;
@@ -370,5 +373,32 @@ describe('MetadataAPI icon normalization', () => {
             includeIcon: true,
             includeInheritedColors: false
         });
+    });
+
+    it('exposes tag-view-specific pin helpers through the API when metadata service is available', async () => {
+        plugin.metadataService = {
+            setFolderStyle: vi.fn(),
+            getFolderDisplayData: vi.fn(),
+            isFilePinnedInTagView: vi.fn().mockReturnValue(true),
+            togglePinnedInTagView: vi.fn().mockResolvedValue(undefined)
+        } as unknown as typeof plugin.metadataService;
+
+        const metadataAPI = new MetadataAPI(api);
+        const file = { path: 'Vault/Note.md' } as never;
+        const metadataService = plugin.metadataService as MetadataServiceMock;
+
+        expect(metadataAPI.isPinnedInTagView(file, 'projects')).toBe(true);
+
+        await metadataAPI.pinInTagView(file, 'projects');
+        expect(metadataService.togglePinnedInTagView).not.toHaveBeenCalled();
+
+        metadataService.isFilePinnedInTagView = vi.fn().mockReturnValue(false);
+        await metadataAPI.pinInTagView(file, 'projects');
+        expect(metadataService.togglePinnedInTagView).toHaveBeenCalledWith('Vault/Note.md', 'projects');
+
+        metadataService.togglePinnedInTagView = vi.fn().mockResolvedValue(undefined);
+        metadataService.isFilePinnedInTagView = vi.fn().mockReturnValue(true);
+        await metadataAPI.unpinFromTagView(file, 'projects');
+        expect(metadataService.togglePinnedInTagView).toHaveBeenCalledWith('Vault/Note.md', 'projects');
     });
 });

--- a/tests/hooks/listPaneData/listItems.test.ts
+++ b/tests/hooks/listPaneData/listItems.test.ts
@@ -54,6 +54,7 @@ function createListConfig(pinnedNotes: ListPaneConfig['pinnedNotes']): ListPaneC
         folderTreeSortOverrides: DEFAULT_SETTINGS.folderTreeSortOverrides,
         noteGrouping: DEFAULT_SETTINGS.noteGrouping,
         pinnedNotes,
+        pinnedTagOrderByTag: DEFAULT_SETTINGS.pinnedTagOrderByTag,
         propertyAppearances: DEFAULT_SETTINGS.propertyAppearances,
         showFileTags: false,
         showPinnedGroupHeader: true,
@@ -103,9 +104,12 @@ describe('buildListItems pinned display scope', () => {
             getFileTimestamps: () => ({ created: 0, modified: 0 }),
             hiddenFileState: new Map(),
             hiddenTags: [],
-            listConfig: createListConfig({
-                [childFile.path]: { folder: false, tag: true, property: false }
-            }),
+            listConfig: {
+                ...createListConfig({}),
+                pinnedTagOrderByTag: {
+                    'work/anthropic': [childFile.path]
+                }
+            },
             searchMetaMap: new Map(),
             selectedFolder: null,
             selectedProperty: null,
@@ -140,9 +144,12 @@ describe('buildListItems pinned display scope', () => {
             getFileTimestamps: () => ({ created: 0, modified: 0 }),
             hiddenFileState: new Map(),
             hiddenTags: [],
-            listConfig: createListConfig({
-                [childFile.path]: { folder: false, tag: true, property: false }
-            }),
+            listConfig: {
+                ...createListConfig({}),
+                pinnedTagOrderByTag: {
+                    'work/anthropic': [childFile.path]
+                }
+            },
             searchMetaMap: new Map(),
             selectedFolder: null,
             selectedProperty: null,
@@ -183,9 +190,12 @@ describe('buildListItems pinned display scope', () => {
             getFileTimestamps: () => ({ created: 0, modified: 0 }),
             hiddenFileState: new Map(),
             hiddenTags: [],
-            listConfig: createListConfig({
-                [valueFile.path]: { folder: false, tag: false, property: true }
-            }),
+            listConfig: {
+                ...createListConfig({}),
+                pinnedNotes: {
+                    [valueFile.path]: { folder: false, tag: false, property: true }
+                }
+            },
             searchMetaMap: new Map(),
             selectedFolder: null,
             selectedProperty: buildPropertyKeyNodeId('status'),
@@ -226,9 +236,12 @@ describe('buildListItems pinned display scope', () => {
             getFileTimestamps: () => ({ created: 0, modified: 0 }),
             hiddenFileState: new Map(),
             hiddenTags: [],
-            listConfig: createListConfig({
-                [valueFile.path]: { folder: false, tag: false, property: true }
-            }),
+            listConfig: {
+                ...createListConfig({}),
+                pinnedNotes: {
+                    [valueFile.path]: { folder: false, tag: false, property: true }
+                }
+            },
             searchMetaMap: new Map(),
             selectedFolder: null,
             selectedProperty: buildPropertyValueNodeId('status', 'work/anthropic'),

--- a/tests/services/FileMetadataService.test.ts
+++ b/tests/services/FileMetadataService.test.ts
@@ -146,6 +146,44 @@ describe('FileMetadataService frontmatter integration', () => {
         expect(settingsProvider.settings.pinnedNotes?.['Vault/One.md']).toEqual({ folder: false, tag: false, property: true });
     });
 
+    it('toggles pins only within the selected tag view', async () => {
+        settingsProvider.settings.pinnedTagOrderByTag = {};
+
+        await service.togglePinnedInTagView('Vault/One.md', 'Projects/Alpha');
+
+        expect(service.isPinnedInTagView('Vault/One.md', 'projects/alpha')).toBe(true);
+        expect(service.isPinnedInTagView('Vault/One.md', 'projects/beta')).toBe(false);
+        expect(settingsProvider.settings.pinnedTagOrderByTag).toEqual({
+            'projects/alpha': ['Vault/One.md']
+        });
+
+        await service.togglePinnedInTagView('Vault/One.md', 'Projects/Alpha');
+
+        expect(service.isPinnedInTagView('Vault/One.md', 'projects/alpha')).toBe(false);
+    });
+
+    it('reorders pinned files within a tag view and persists order', async () => {
+        settingsProvider.settings.pinnedTagOrderByTag = {
+            projects: ['Vault/One.md', 'Vault/Two.md']
+        };
+
+        await service.reorderPinnedInTagView('Projects', ['Vault/Two.md', 'Vault/One.md']);
+
+        expect(service.getPinnedTagOrder('projects')).toEqual(['Vault/Two.md', 'Vault/One.md']);
+    });
+
+    it('updates pinned tag order when files are renamed or deleted', async () => {
+        settingsProvider.settings.pinnedTagOrderByTag = {
+            projects: ['Vault/One.md', 'Vault/Two.md']
+        };
+
+        await service.handleFileRename('Vault/One.md', 'Vault/Renamed.md');
+        expect(service.getPinnedTagOrder('projects')).toEqual(['Vault/Renamed.md', 'Vault/Two.md']);
+
+        await service.handleFileDelete('Vault/Two.md');
+        expect(service.getPinnedTagOrder('projects')).toEqual(['Vault/Renamed.md']);
+    });
+
     it('treats legacy folder+tag pins as pinned in property context', () => {
         settingsProvider.settings.pinnedNotes = {
             'Vault/Legacy.md': { folder: true, tag: true }

--- a/tests/services/FileMetadataService.test.ts
+++ b/tests/services/FileMetadataService.test.ts
@@ -184,6 +184,28 @@ describe('FileMetadataService frontmatter integration', () => {
         expect(service.getPinnedTagOrder('projects')).toEqual(['Vault/Renamed.md']);
     });
 
+    it('migrates pinned tag order keys when tags are renamed or deleted', () => {
+        settingsProvider.settings.pinnedTagOrderByTag = {
+            project: ['Vault/Root.md'],
+            'project/child': ['Vault/Child.md'],
+            other: ['Vault/Other.md']
+        };
+
+        const renamed = service.applyTagRenameToPinnedTagOrder(settingsProvider.settings, 'project', 'areas');
+        expect(renamed).toBe(true);
+        expect(settingsProvider.settings.pinnedTagOrderByTag).toEqual({
+            areas: ['Vault/Root.md'],
+            'areas/child': ['Vault/Child.md'],
+            other: ['Vault/Other.md']
+        });
+
+        const deleted = service.applyTagDeleteToPinnedTagOrder(settingsProvider.settings, 'areas');
+        expect(deleted).toBe(true);
+        expect(settingsProvider.settings.pinnedTagOrderByTag).toEqual({
+            other: ['Vault/Other.md']
+        });
+    });
+
     it('treats legacy folder+tag pins as pinned in property context', () => {
         settingsProvider.settings.pinnedNotes = {
             'Vault/Legacy.md': { folder: true, tag: true }


### PR DESCRIPTION
## Summary
- add tag-scoped pinned ordering for tag views only
- make pinned rows reorderable with persistent order
- keep non-pinned sorting and grouping unchanged

## What changed
- store tag-view-specific pinned order in plugin settings
- change tag-view pin actions so they only affect the current tag
- keep folder/property pin behavior unchanged
- add optimistic reorder updates to avoid flicker after drag
- refine drag interaction so the whole pinned row can be dragged while normal clicks still work
- fix consistency issues for bulk pin in tag views, tag rename/delete cleanup, and API access to tag-view pin state

## Testing
- npm test -- tests/services/FileMetadataService.test.ts tests/hooks/listPaneData/listItems.test.ts tests/utils/fileFinder.test.ts tests/api/MetadataAPI.test.ts
- npx tsc -noEmit -skipLibCheck
- npm run build