### PR TITLE
Add settings to control single-pane navigation and double-click behavior

### DIFF
--- a/src/components/FolderItem.tsx
+++ b/src/components/FolderItem.tsx
@@ -228,7 +228,6 @@ export const FolderItem = React.memo(function FolderItem({
         return classes.join(' ');
     }, [applyColorToName, hasFolderNote]);
 
-    // Stable event handlers
     const handleDoubleClick = useCallback(() => {
         if (hasChildren) {
             onToggle();

--- a/src/components/NotebookNavigatorComponent.tsx
+++ b/src/components/NotebookNavigatorComponent.tsx
@@ -414,8 +414,10 @@ export const NotebookNavigatorComponent = React.memo(
                 const raf = window.requestAnimationFrame(() => {
                     setSuppressPaneTransitions(false);
                 });
-                uiDispatch({ type: 'SET_SINGLE_PANE_VIEW', view: 'files' });
-                uiDispatch({ type: 'SET_FOCUSED_PANE', pane: 'files' });
+
+                const singlePaneView = settings.customNavPaneClickBehavior ? 'navigation' : 'files';
+                uiDispatch({ type: 'SET_SINGLE_PANE_VIEW', view: singlePaneView });
+                uiDispatch({ type: 'SET_FOCUSED_PANE', pane: singlePaneView });
                 return () => {
                     window.cancelAnimationFrame(raf);
                 };
@@ -424,7 +426,7 @@ export const NotebookNavigatorComponent = React.memo(
             const preferredView = preferredSinglePaneView.current;
             uiDispatch({ type: 'SET_SINGLE_PANE_VIEW', view: preferredView });
             uiDispatch({ type: 'SET_FOCUSED_PANE', pane: preferredView });
-        }, [isMobile, uiDispatch, uiState.dualPane]);
+        }, [isMobile, settings.customNavPaneClickBehavior, uiDispatch, uiState.dualPane]);
 
         useEffect(() => {
             if (!uiState.singlePane) {

--- a/src/components/VirtualFolderItem.tsx
+++ b/src/components/VirtualFolderItem.tsx
@@ -260,7 +260,6 @@ export const VirtualFolderComponent = React.memo(function VirtualFolderComponent
         },
         [onSelect, onToggle]
     );
-
     useEffect(() => {
         const chevronEl = chevronRef.current;
         if (!chevronEl) {

--- a/src/hooks/navigationPane/useNavigationPaneTreeInteractions.ts
+++ b/src/hooks/navigationPane/useNavigationPaneTreeInteractions.ts
@@ -153,7 +153,7 @@ export function useNavigationPaneTreeInteractions({
             }
 
             if (uiState.singlePane) {
-                if (shouldExpandOnly) {
+                if (shouldExpandOnly || settings.customNavDoubleClickBehavior) {
                     uiDispatch({ type: 'SET_FOCUSED_PANE', pane: 'navigation' });
                 } else {
                     uiDispatch({ type: 'SET_SINGLE_PANE_VIEW', view: 'files' });
@@ -357,7 +357,7 @@ export function useNavigationPaneTreeInteractions({
     const focusAfterTreeSelection = useCallback(
         (keepNavigationFocus: boolean) => {
             if (uiState.singlePane) {
-                if (keepNavigationFocus) {
+                if (keepNavigationFocus || settings.customNavDoubleClickBehavior) {
                     uiDispatch({ type: 'SET_FOCUSED_PANE', pane: 'navigation' });
                 } else {
                     uiDispatch({ type: 'SET_SINGLE_PANE_VIEW', view: 'files' });
@@ -368,7 +368,7 @@ export function useNavigationPaneTreeInteractions({
 
             uiDispatch({ type: 'SET_FOCUSED_PANE', pane: 'navigation' });
         },
-        [uiDispatch, uiState.singlePane]
+        [settings.customNavDoubleClickBehavior, uiDispatch, uiState.singlePane]
     );
 
     const applyTreeSelection = useCallback(

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1071,6 +1071,14 @@ export const STRINGS_EN = {
                     files: 'List pane'
                 }
             },
+            customNavPaneClickBehavior: {
+                name: 'Pin navigation pane in single-pane mode',
+                desc: 'When enabled, clicking a navigation item in single-pane mode stays in the navigation pane instead of switching to the list pane.'
+            },
+            customNavDoubleClickBehavior: {
+                name: 'Disable click-to-list in single-pane mode',
+                desc: 'When enabled, clicking a folder in single-pane mode selects it without switching to the file list. Expand and collapse still work normally.'
+            },
             toolbarButtons: {
                 name: 'Toolbar buttons',
                 desc: 'Choose which buttons appear in the toolbar. Hidden buttons remain accessible via commands and menus.',

--- a/src/i18n/locales/zh_cn.ts
+++ b/src/i18n/locales/zh_cn.ts
@@ -1068,6 +1068,14 @@ export const STRINGS_ZH_CN = {
                     files: '列表窗格'
                 }
             },
+            customNavPaneClickBehavior: {
+                name: '单窗格切换固定为目录导航',
+                desc: '启用后，单窗格模式下点击导航项时停留在导航栏，不会切换到文档列表。'
+            },
+            customNavDoubleClickBehavior: {
+                name: '单窗格禁用单击跳转文件列表',
+                desc: '启用后，单窗格模式下点击文件夹不会跳转到文件列表，仅选中文件夹并支持展开或折叠。'
+            },
             toolbarButtons: {
                 name: '工具栏按钮',
                 desc: '选择在工具栏中显示哪些按钮。隐藏的按钮仍可通过命令和菜单访问。',

--- a/src/settings/defaultSettings.ts
+++ b/src/settings/defaultSettings.ts
@@ -157,6 +157,8 @@ export const DEFAULT_SETTINGS: NotebookNavigatorSettings = {
     // General tab - View
     startView: 'files',
     showInfoButtons: true,
+    customNavPaneClickBehavior: false,
+    customNavDoubleClickBehavior: false,
 
     // General tab - Homepage
     homepage: {

--- a/src/settings/tabs/GeneralTab.ts
+++ b/src/settings/tabs/GeneralTab.ts
@@ -585,6 +585,28 @@ export function renderGeneralTab(context: SettingsTabContext): void {
 
     addToggleSetting(
         behaviorGroup.addSetting,
+        strings.settings.items.customNavPaneClickBehavior.name,
+        strings.settings.items.customNavPaneClickBehavior.desc,
+        () => plugin.settings.customNavPaneClickBehavior,
+        value => {
+            plugin.settings.customNavPaneClickBehavior = value;
+            void plugin.saveSettingsAndUpdate();
+        }
+    );
+
+    addToggleSetting(
+        behaviorGroup.addSetting,
+        strings.settings.items.customNavDoubleClickBehavior.name,
+        strings.settings.items.customNavDoubleClickBehavior.desc,
+        () => plugin.settings.customNavDoubleClickBehavior,
+        value => {
+            plugin.settings.customNavDoubleClickBehavior = value;
+            void plugin.saveSettingsAndUpdate();
+        }
+    );
+
+    addToggleSetting(
+        behaviorGroup.addSetting,
         strings.settings.items.createNewNotesInNewTab.name,
         strings.settings.items.createNewNotesInNewTab.desc,
         () => plugin.settings.createNewNotesInNewTab,

--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -387,6 +387,8 @@ export interface NotebookNavigatorSettings {
     // General tab - View
     startView: 'navigation' | 'files';
     showInfoButtons: boolean;
+    customNavPaneClickBehavior: boolean;
+    customNavDoubleClickBehavior: boolean;
 
     // General tab - Homepage
     homepage: HomepageSetting;


### PR DESCRIPTION
- Add customNavPaneClickBehavior: pin navigation pane in single-pane mode
- Add customNavDoubleClickBehavior: disable click-to-list in single-pane mode
- When enabled, handleFolderClick stays on navigation pane instead of switching to file list
- Fix build errors: missing guardedContentClick in FolderItem, duplicate declaration in VirtualFolderItem

