### PR TITLE
Fix drag ghost not appearing during drag operations

### DIFF
--- a/src/utils/dragGhost.ts
+++ b/src/utils/dragGhost.ts
@@ -181,19 +181,19 @@ export function createDragGhostManager(): DragGhostManager {
         const resolvedIcon = resolveIcon(options);
         const ownerDocument = options.customElement?.ownerDocument ?? activeDocument;
 
-        const baseGhost = options.customElement ?? ownerDocument.createDiv();
+        const baseGhost = options.customElement ?? ownerDocument.createElement('div');
         if (!baseGhost.classList.contains('nn-drag-ghost')) {
             baseGhost.classList.add('nn-drag-ghost');
         }
 
         if (!options.customElement) {
             if (options.itemCount && options.itemCount > 1) {
-                const info = ownerDocument.createDiv();
+                const info = ownerDocument.createElement('div');
                 info.className = 'nn-drag-ghost-badge';
                 info.textContent = `${options.itemCount}`;
                 baseGhost.appendChild(info);
             } else {
-                const iconWrapper = ownerDocument.createDiv();
+                const iconWrapper = ownerDocument.createElement('div');
                 iconWrapper.className = 'nn-drag-ghost-icon';
                 const iconColor = options.iconColor ?? '#ffffff';
                 iconWrapper.style.color = iconColor;


### PR DESCRIPTION
## Summary
`ownerDocument.createDiv()` (introduced in 17c65ac7 for popout-window correctness) throws `HierarchyRequestError` when called on a `Document`, so the custom drag ghost never appears. Fixed by switching to `ownerDocument.createElement('div')` at three call sites in `src/utils/dragGhost.ts`.

## Root cause
Obsidian patches `createDiv` onto both `Element.prototype` and `Document.prototype`. On an `Element` it appends to `this`; on a `Document` it tries to append to the document root, which is invalid (a document can only have one root element) and throws. The exception fires synchronously inside `showGhost`, before the ghost is appended to body — users see only the native browser preview flash for one frame.

Commit 17c65ac7 swapped `document.createElement('div')` (safe — eslint flagged the global `document`) for `ownerDocument.createDiv()` (broken — auto-appends to Document). Three call sites were affected.

## Investigation
Instrumented `showGhost` / `hideGhost` and every cleanup path in a test vault. The console showed `showGhost` throwing synchronously — no `dragend` / `drop` involved — with the stack pointing into `HTMLDocument.createDiv` (`enhance.js`). Grepped the rest of `src/` for the same anti-pattern; only `dragGhost.ts` was affected.

## Fix
Three identical line changes: `ownerDocument.createDiv()` → `ownerDocument.createElement('div')`. The `obsidianmd/prefer-create-el` rule only flags `document` and `activeDocument` identifiers, so the local `ownerDocument` variable passes lint cleanly without disable directives. Same pattern is already used in `src/settings/subSettings.ts` and `src/utils/androidFontScale.ts`.

## Verification
Re-tested on Obsidian 1.12.7 / macOS 26.2 with the patched build: ghost follows the cursor through the full drag for single-file drags (icon in dark circle) and multi-select drags (red count badge); drop completes correctly. `npm run lint` and `npm run build` both clean.

https://github.com/user-attachments/assets/dbe8ec93-b0cf-4663-bfea-18bb64224aca


## Tests
None added. The bug only manifests under Obsidian's runtime patching of `Document.prototype.createDiv`, which is absent from the vitest node environment, the `obsidian` stub, and jsdom. A behavioral test would require substantial DOM mocking for a 3-line fix and would introduce the first DOM-test pattern in the repo — happy to add one if you'd prefer that precedent.

Closes #1103