### PR TITLE
Tune Dependabot update groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,22 @@ updates:
       time: "06:00"
       timezone: Europe/Stockholm
     groups:
+      react-runtime:
+        dependency-type: production
+        patterns:
+          - "react"
+          - "react-dom"
       npm-development:
         dependency-type: development
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "eslint"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "@eslint/*"
+        update-types:
+          - "version-update:semver-major"
     open-pull-requests-limit: 5
 
   - package-ecosystem: github-actions


### PR DESCRIPTION
Groups React runtime updates and holds ESLint major updates until peer dependencies support them.