### PR TITLE
Configure Dependabot to keep React 18

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,18 @@ updates:
         patterns:
           - "*"
     ignore:
+      - dependency-name: "react"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "react-dom"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "@types/react"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "@types/react-dom"
+        update-types:
+          - "version-update:semver-major"
       - dependency-name: "eslint"
         update-types:
           - "version-update:semver-major"


### PR DESCRIPTION
Keep Dependabot from opening React 19 runtime and type updates.