### PR TITLE
Feature request: Reveal active file button in navigation pane header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ scripts/build-local.sh
 # Release lock file
 .release.lock
 
+# Bun lock file
+bun.lock
+
 # Web site
 web/
 

--- a/src/components/NavigationPaneHeader.tsx
+++ b/src/components/NavigationPaneHeader.tsx
@@ -66,6 +66,7 @@ export function NavigationPaneHeader({
     const showHiddenItemsButton = navigationVisibility.hiddenItems;
     const showRootReorderButton = navigationVisibility.rootReorder;
     const showNewFolderButton = navigationVisibility.newFolder;
+    const showRevealActiveFileButton = navigationVisibility.revealActiveFile;
 
     if (!hasProfiles) {
         return null;
@@ -125,7 +126,8 @@ export function NavigationPaneHeader({
         showHiddenItemsButton ||
         showCalendarButton ||
         showRootReorderButton ||
-        showNewFolderButton;
+        showNewFolderButton ||
+        showRevealActiveFileButton;
 
     if (!shouldRenderDesktopHeader) {
         return null;
@@ -232,6 +234,26 @@ export function NavigationPaneHeader({
                             tabIndex={-1}
                         >
                             <ServiceIcon iconId={resolveUXIcon(settings.interfaceIcons, 'nav-new-folder')} />
+                        </button>
+                    ) : null}
+                    {showRevealActiveFileButton ? (
+                        <button
+                            className="nn-icon-button"
+                            aria-label={strings.paneHeader.revealActiveFile}
+                            onClick={() => {
+                                runAsyncAction(async () => {
+                                    const activeFile = plugin.app.workspace.getActiveFile();
+                                    if (!activeFile || !activeFile.parent) {
+                                        return;
+                                    }
+                                    await plugin.activateView();
+                                    await plugin.revealFileInActualFolder(activeFile, { showHiddenFileNotice: true });
+                                });
+                            }}
+                            disabled={!plugin.app.workspace.getActiveFile()}
+                            tabIndex={-1}
+                        >
+                            <ServiceIcon iconId="lucide-folder-search" />
                         </button>
                     ) : null}
                 </div>

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -162,7 +162,8 @@ export const STRINGS_EN = {
         showFilesFromSubfolders: 'Show files from subfolders',
         showNotesFromDescendants: 'Show notes from descendants',
         showFilesFromDescendants: 'Show files from descendants',
-        search: 'Search' // Tooltip for search button (English: Search)
+        search: 'Search', // Tooltip for search button (English: Search)
+        revealActiveFile: 'Reveal active file' // Tooltip for button that reveals the currently open file in the navigator (English: Reveal active file)
     },
     // Search input
     searchInput: {

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -162,7 +162,8 @@ export const STRINGS_RU = {
         showFilesFromSubfolders: 'Показать файлы из подпапок',
         showNotesFromDescendants: 'Показать заметки из потомков',
         showFilesFromDescendants: 'Показать файлы из потомков',
-        search: 'Поиск' // Tooltip for search button (English: Search)
+        search: 'Поиск', // Tooltip for search button (English: Search)
+        revealActiveFile: 'Показать активный файл' // Tooltip for button that reveals the currently open file in the navigator (English: Reveal active file)
     },
     // Search input
     searchInput: {

--- a/src/settings/defaultSettings.ts
+++ b/src/settings/defaultSettings.ts
@@ -187,7 +187,8 @@ export const DEFAULT_SETTINGS: NotebookNavigatorSettings = {
             calendar: true,
             hiddenItems: true,
             rootReorder: true,
-            newFolder: true
+            newFolder: true,
+            revealActiveFile: false
         },
         list: {
             back: true,

--- a/src/settings/tabs/ToolbarButtonsSetting.ts
+++ b/src/settings/tabs/ToolbarButtonsSetting.ts
@@ -36,7 +36,8 @@ const NAVIGATION_TOOLBAR_BUTTONS: ToolbarButtonConfig<NavigationToolbarButtonId>
     { id: 'hiddenItems', iconType: 'ux', iconId: 'nav-hidden-items', label: strings.paneHeader.showExcludedItems },
     { id: 'calendar', iconType: 'ux', iconId: 'nav-calendar', label: strings.paneHeader.showCalendar },
     { id: 'rootReorder', iconType: 'ux', iconId: 'nav-root-reorder', label: strings.paneHeader.reorderRootFolders },
-    { id: 'newFolder', iconType: 'ux', iconId: 'nav-new-folder', label: strings.paneHeader.newFolder }
+    { id: 'newFolder', iconType: 'ux', iconId: 'nav-new-folder', label: strings.paneHeader.newFolder },
+    { id: 'revealActiveFile', iconType: 'raw', iconId: 'lucide-folder-search', label: strings.paneHeader.revealActiveFile }
 ];
 
 const LIST_TOOLBAR_BUTTONS: ToolbarButtonConfig<ListToolbarButtonId>[] = [

--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -401,7 +401,7 @@ export function isWordCountPlacement(value: unknown): value is WordCountPlacemen
 }
 
 /** Buttons available in the navigation toolbar */
-export type NavigationToolbarButtonId = 'toggleDualPane' | 'expandCollapse' | 'calendar' | 'hiddenItems' | 'rootReorder' | 'newFolder';
+export type NavigationToolbarButtonId = 'toggleDualPane' | 'expandCollapse' | 'calendar' | 'hiddenItems' | 'rootReorder' | 'newFolder' | 'revealActiveFile';
 
 /** Buttons available in the list toolbar */
 export type ListToolbarButtonId = 'back' | 'search' | 'descendants' | 'sort' | 'appearance' | 'newNote';


### PR DESCRIPTION
Currently there's a reveal-file command in the command palette, but there's no quick button for it in the navigation pane header.

Would be great to have a toolbar button that reveals and selects the currently open file in the navigator - similar to how other file managers handle this.