### PR TITLE
feat: add Reveal Active File toolbar button and command

### DIFF
--- a/src/components/NavigationPaneHeader.tsx
+++ b/src/components/NavigationPaneHeader.tsx
@@ -67,6 +67,7 @@ export function NavigationPaneHeader({
     const showHiddenItemsButton = navigationVisibility.hiddenItems;
     const showRootReorderButton = navigationVisibility.rootReorder;
     const showNewFolderButton = navigationVisibility.newFolder;
+    const showRevealActiveFileButton = navigationVisibility.revealActiveFile;
 
     if (!hasProfiles) {
         return null;
@@ -126,7 +127,8 @@ export function NavigationPaneHeader({
         showHiddenItemsButton ||
         showCalendarButton ||
         showRootReorderButton ||
-        showNewFolderButton;
+        showNewFolderButton ||
+        showRevealActiveFileButton;
 
     if (!shouldRenderDesktopHeader) {
         return null;
@@ -240,6 +242,26 @@ export function NavigationPaneHeader({
                             tabIndex={-1}
                         >
                             <ServiceIcon iconId={resolveUXIcon(settings.interfaceIcons, 'nav-new-folder')} />
+                        </button>
+                    ) : null}
+                    {showRevealActiveFileButton ? (
+                        <button
+                            className="nn-icon-button"
+                            aria-label={strings.paneHeader.revealActiveFile}
+                            onClick={() => {
+                                runAsyncAction(async () => {
+                                    const activeFile = plugin.app.workspace.getActiveFile();
+                                    if (!activeFile || !activeFile.parent) {
+                                        return;
+                                    }
+                                    await plugin.activateView();
+                                    await plugin.revealFileInActualFolder(activeFile, { showHiddenFileNotice: true });
+                                });
+                            }}
+                            disabled={!plugin.app.workspace.getActiveFile()}
+                            tabIndex={-1}
+                        >
+                            <ServiceIcon iconId="lucide-folder-search" />
                         </button>
                     ) : null}
                 </div>

--- a/src/i18n/locales/ar.ts
+++ b/src/i18n/locales/ar.ts
@@ -164,7 +164,8 @@ export const STRINGS_AR = {
         showFilesFromSubfolders: 'إظهار الملفات من المجلدات الفرعية',
         showNotesFromDescendants: 'إظهار الملاحظات من الفروع',
         showFilesFromDescendants: 'إظهار الملفات من الفروع',
-        search: 'بحث' // Tooltip for search button (English: Search)
+        search: 'بحث', // Tooltip for search button (English: Search)
+        revealActiveFile: 'Reveal active file' // Tooltip for button that reveals the currently open file in the navigator (English: Reveal active file)
     },
     // Search input
     searchInput: {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -163,7 +163,8 @@ export const STRINGS_DE = {
         showFilesFromSubfolders: 'Dateien aus Unterordnern anzeigen',
         showNotesFromDescendants: 'Notizen aus Nachkommen anzeigen',
         showFilesFromDescendants: 'Dateien aus Nachkommen anzeigen',
-        search: 'Suchen' // Tooltip for search button (English: Search)
+        search: 'Suchen', // Tooltip for search button (English: Search)
+        revealActiveFile: 'Aktive Datei anzeigen' // Tooltip for button that reveals the currently open file in the navigator (English: Reveal active file)
     },
     // Search input
     searchInput: {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -164,7 +164,8 @@ export const STRINGS_EN = {
         showFilesFromSubfolders: 'Show files from subfolders',
         showNotesFromDescendants: 'Show notes from descendants',
         showFilesFromDescendants: 'Show files from descendants',
-        search: 'Search' // Tooltip for search button (English: Search)
+        search: 'Search', // Tooltip for search button (English: Search)
+        revealActiveFile: 'Reveal active file' // Tooltip for button that reveals the currently open file in the navigator (English: Reveal active file)
     },
     // Search input
     searchInput: {

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -163,7 +163,8 @@ export const STRINGS_ES = {
         showFilesFromSubfolders: 'Mostrar archivos de subcarpetas',
         showNotesFromDescendants: 'Mostrar notas de descendientes',
         showFilesFromDescendants: 'Mostrar archivos de descendientes',
-        search: 'Buscar' // Tooltip for search button (English: Search)
+        search: 'Buscar', // Tooltip for search button (English: Search)
+        revealActiveFile: 'Reveal active file' // Tooltip for button that reveals the currently open file in the navigator (English: Reveal active file)
     },
     // Search input
     searchInput: {

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -164,7 +164,8 @@ export const STRINGS_FR = {
         showFilesFromSubfolders: 'Afficher les fichiers des sous-dossiers',
         showNotesFromDescendants: 'Afficher les notes des descendants',
         showFilesFromDescendants: 'Afficher les fichiers des descendants',
-        search: 'Rechercher' // Tooltip for search button (English: Search)
+        search: 'Rechercher', // Tooltip for search button (English: Search)
+        revealActiveFile: 'Révéler le fichier actif' // Tooltip for button that reveals the currently open file in the navigator (English: Reveal active file)
     },
     // Search input
     searchInput: {

--- a/src/i18n/locales/id.ts
+++ b/src/i18n/locales/id.ts
@@ -164,7 +164,8 @@ export const STRINGS_ID = {
         showFilesFromSubfolders: 'Tampilkan file dari subfolder',
         showNotesFromDescendants: 'Tampilkan catatan dari turunan',
         showFilesFromDescendants: 'Tampilkan file dari turunan',
-        search: 'Cari'
+        search: 'Cari',
+        revealActiveFile: 'Reveal active file'
     },
     // Search input
     searchInput: {

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -164,7 +164,8 @@ export const STRINGS_IT = {
         showFilesFromSubfolders: 'Mostra file da sottocartelle',
         showNotesFromDescendants: 'Mostra note da discendenti',
         showFilesFromDescendants: 'Mostra file da discendenti',
-        search: 'Cerca' // Tooltip for search button (English: Search)
+        search: 'Cerca', // Tooltip for search button (English: Search)
+        revealActiveFile: 'Reveal active file' // Tooltip for button that reveals the currently open file in the navigator (English: Reveal active file)
     },
     // Search input
     searchInput: {

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -163,7 +163,8 @@ export const STRINGS_JA = {
         showFilesFromSubfolders: 'サブフォルダのファイルを表示',
         showNotesFromDescendants: '子孫のノートを表示',
         showFilesFromDescendants: '子孫のファイルを表示',
-        search: '検索' // Tooltip for search button (English: Search)
+        search: '検索', // Tooltip for search button (English: Search)
+        revealActiveFile: 'Reveal active file' // Tooltip for button that reveals the currently open file in the navigator (English: Reveal active file)
     },
     // Search input
     searchInput: {

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -163,7 +163,8 @@ export const STRINGS_KO = {
         showFilesFromSubfolders: '하위 폴더 파일 표시',
         showNotesFromDescendants: '하위 항목 노트 표시',
         showFilesFromDescendants: '하위 항목 파일 표시',
-        search: '검색' // Tooltip for search button (English: Search)
+        search: '검색', // Tooltip for search button (English: Search)
+        revealActiveFile: 'Reveal active file' // Tooltip for button that reveals the currently open file in the navigator (English: Reveal active file)
     },
     // Search input
     searchInput: {

--- a/src/i18n/locales/pl.ts
+++ b/src/i18n/locales/pl.ts
@@ -164,7 +164,8 @@ export const STRINGS_PL = {
         showFilesFromSubfolders: 'Pokaż pliki z podfolderów',
         showNotesFromDescendants: 'Pokaż notatki z potomnych',
         showFilesFromDescendants: 'Pokaż pliki z potomnych',
-        search: 'Szukaj' // Tooltip for search button (English: Search)
+        search: 'Szukaj', // Tooltip for search button (English: Search)
+        revealActiveFile: 'Reveal active file' // Tooltip for button that reveals the currently open file in the navigator (English: Reveal active file)
     },
     // Search input
     searchInput: {

--- a/src/i18n/locales/pt.ts
+++ b/src/i18n/locales/pt.ts
@@ -164,7 +164,8 @@ export const STRINGS_PT = {
         showFilesFromSubfolders: 'Mostrar ficheiros de subpastas',
         showNotesFromDescendants: 'Mostrar notas de descendentes',
         showFilesFromDescendants: 'Mostrar ficheiros de descendentes',
-        search: 'Pesquisar' // Tooltip for search button (English: Search)
+        search: 'Pesquisar', // Tooltip for search button (English: Search)
+        revealActiveFile: 'Reveal active file' // Tooltip for button that reveals the currently open file in the navigator (English: Reveal active file)
     },
     // Search input
     searchInput: {

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -164,7 +164,8 @@ export const STRINGS_RU = {
         showFilesFromSubfolders: 'Показать файлы из подпапок',
         showNotesFromDescendants: 'Показать заметки из потомков',
         showFilesFromDescendants: 'Показать файлы из потомков',
-        search: 'Поиск' // Tooltip for search button (English: Search)
+        search: 'Поиск', // Tooltip for search button (English: Search)
+        revealActiveFile: 'Показать активный файл' // Tooltip for button that reveals the currently open file in the navigator (English: Reveal active file)
     },
     // Search input
     searchInput: {

--- a/src/i18n/locales/tr.ts
+++ b/src/i18n/locales/tr.ts
@@ -164,7 +164,8 @@ export const STRINGS_TR = {
         showFilesFromSubfolders: 'Alt klasörlerden dosyaları göster',
         showNotesFromDescendants: 'Alt öğelerden notları göster',
         showFilesFromDescendants: 'Alt öğelerden dosyaları göster',
-        search: 'Ara' // Tooltip for search button (English: Search)
+        search: 'Ara', // Tooltip for search button (English: Search)
+        revealActiveFile: 'Reveal active file' // Tooltip for button that reveals the currently open file in the navigator (English: Reveal active file)
     },
     // Search input
     searchInput: {

--- a/src/i18n/locales/uk.ts
+++ b/src/i18n/locales/uk.ts
@@ -165,7 +165,8 @@ export const STRINGS_UK = {
         showFilesFromSubfolders: 'Показати файли з підпапок',
         showNotesFromDescendants: 'Показати нотатки з нащадків',
         showFilesFromDescendants: 'Показати файли з нащадків',
-        search: 'Пошук' // Tooltip for search button (English: Search)
+        search: 'Пошук', // Tooltip for search button (English: Search)
+        revealActiveFile: 'Показати активний файл' // Tooltip for button that reveals the currently open file in the navigator (English: Reveal active file)
     },
     // Search input
     searchInput: {

--- a/src/i18n/locales/vi.ts
+++ b/src/i18n/locales/vi.ts
@@ -164,7 +164,8 @@ export const STRINGS_VI = {
         showFilesFromSubfolders: 'Hiện tập tin từ thư mục con',
         showNotesFromDescendants: 'Hiện ghi chú từ phần tử con',
         showFilesFromDescendants: 'Hiện tập tin từ phần tử con',
-        search: 'Tìm kiếm' // Tooltip for search button (English: Search)
+        search: 'Tìm kiếm', // Tooltip for search button (English: Search)
+        revealActiveFile: 'Reveal active file' // Tooltip for button that reveals the currently open file in the navigator (English: Reveal active file)
     },
     // Search input
     searchInput: {

--- a/src/i18n/locales/zh_cn.ts
+++ b/src/i18n/locales/zh_cn.ts
@@ -163,7 +163,8 @@ export const STRINGS_ZH_CN = {
         showFilesFromSubfolders: '显示子文件夹的文件',
         showNotesFromDescendants: '显示后代的笔记',
         showFilesFromDescendants: '显示后代的文件',
-        search: '搜索' // Tooltip for search button (English: Search)
+        search: '搜索', // Tooltip for search button (English: Search)
+        revealActiveFile: 'Reveal active file' // Tooltip for button that reveals the currently open file in the navigator (English: Reveal active file)
     },
     // Search input
     searchInput: {

--- a/src/settings/defaultSettings.ts
+++ b/src/settings/defaultSettings.ts
@@ -196,7 +196,8 @@ export const DEFAULT_SETTINGS: NotebookNavigatorSettings = {
             calendar: true,
             hiddenItems: true,
             rootReorder: true,
-            newFolder: true
+            newFolder: true,
+            revealActiveFile: false
         },
         list: {
             back: true,

--- a/src/settings/tabs/ToolbarButtonsSetting.ts
+++ b/src/settings/tabs/ToolbarButtonsSetting.ts
@@ -36,7 +36,8 @@ const NAVIGATION_TOOLBAR_BUTTONS: ToolbarButtonConfig<NavigationToolbarButtonId>
     { id: 'hiddenItems', iconType: 'ux', iconId: 'nav-hidden-items', label: strings.paneHeader.showExcludedItems },
     { id: 'calendar', iconType: 'ux', iconId: 'nav-calendar', label: strings.paneHeader.showCalendar },
     { id: 'rootReorder', iconType: 'ux', iconId: 'nav-root-reorder', label: strings.paneHeader.reorderRootFolders },
-    { id: 'newFolder', iconType: 'ux', iconId: 'nav-new-folder', label: strings.paneHeader.newFolder }
+    { id: 'newFolder', iconType: 'ux', iconId: 'nav-new-folder', label: strings.paneHeader.newFolder },
+    { id: 'revealActiveFile', iconType: 'raw', iconId: 'lucide-folder-search', label: strings.paneHeader.revealActiveFile }
 ];
 
 const LIST_TOOLBAR_BUTTONS: ToolbarButtonConfig<ListToolbarButtonId>[] = [

--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -469,7 +469,7 @@ export function showsCharacterCount(display: TextCountDisplay): boolean {
 }
 
 /** Buttons available in the navigation toolbar */
-export type NavigationToolbarButtonId = 'toggleDualPane' | 'expandCollapse' | 'calendar' | 'hiddenItems' | 'rootReorder' | 'newFolder';
+export type NavigationToolbarButtonId = 'toggleDualPane' | 'expandCollapse' | 'calendar' | 'hiddenItems' | 'rootReorder' | 'newFolder' | 'revealActiveFile';
 
 /** Buttons available in the list toolbar */
 export type ListToolbarButtonId = 'back' | 'search' | 'descendants' | 'sort' | 'appearance' | 'newNote';


### PR DESCRIPTION
### What was done

Adds an optional button to the navigation pane toolbar and a palette command that highlights and scrolls to the currently open file in the navigator tree. The button is enabled in toolbar settings, disabled by default.

### Changes

- `src/components/NavigationPaneHeader.tsx` - the toolbar button itself
- `src/settings/types.ts`, `defaultSettings.ts` - `revealActiveFile` field in settings
- `src/settings/tabs/ToolbarButtonsSetting.ts` - button registration in settings
- `src/services/commands/registerNavigatorCommands.ts` - palette command
- `src/i18n/locales/{en,ru}.ts` + other locales - `revealActiveFile` string
