### PR TITLE
feat: folder note sync, empty-folder headers, and folder-group context menu

### DIFF
--- a/src/components/ListPane.tsx
+++ b/src/components/ListPane.tsx
@@ -45,10 +45,10 @@
  */
 
 import React, { useRef, useEffect, useImperativeHandle, forwardRef, useState, useMemo, useLayoutEffect } from 'react';
-import { TFile, Platform, type App } from 'obsidian';
+import { Menu, TFile, TFolder, Platform, type App } from 'obsidian';
 import { Virtualizer } from '@tanstack/react-virtual';
 import { useSelectionState, useSelectionDispatch } from '../context/SelectionContext';
-import { useServices } from '../context/ServicesContext';
+import { useServices, useMetadataService, useTagOperations, usePropertyOperations, useCommandQueue } from '../context/ServicesContext';
 import { useSettingsState, useActiveProfile, useSettingsDerived } from '../context/SettingsContext';
 import { useUIDispatch, useUIState } from '../context/UIStateContext';
 import { useExpansionDispatch, useExpansionState } from '../context/ExpansionContext';
@@ -75,7 +75,7 @@ import { ManualSortListContent } from './listPane/ManualSortListContent';
 import type { FileItemStorageHelpers } from './FileItem';
 import { type SearchShortcut } from '../types/shortcuts';
 import { type SearchNavFilterState } from '../types/search';
-import { EMPTY_LIST_MENU_TYPE } from '../utils/contextMenu';
+import { EMPTY_LIST_MENU_TYPE, buildFolderMenu } from '../utils/contextMenu';
 import { useUXPreferences } from '../context/UXPreferencesContext';
 import { type InclusionOperator } from '../utils/filterSearch';
 import type { FolderDecorationModel } from '../utils/folderDecoration';
@@ -270,7 +270,11 @@ function ListPaneTitleChrome({
 
 export const ListPane = React.memo(
     forwardRef<ListPaneHandle, ListPaneProps>(function ListPane(props, ref) {
-        const { app, isMobile, plugin, fileSystemOps } = useServices();
+        const { app, isMobile, plugin, fileSystemOps, tagTreeService, propertyTreeService } = useServices();
+        const metadataService = useMetadataService();
+        const tagOperations = useTagOperations();
+        const propertyOperations = usePropertyOperations();
+        const commandQueue = useCommandQueue();
         const {
             onNavigateToFolder,
             onRevealTag,
@@ -292,9 +296,72 @@ export const ListPane = React.memo(
         const showCalendar = uxPreferences.showCalendar;
         const appearanceSettings = useListPaneAppearance();
         const { getFileDisplayName, getDB, getFileTimestamps, hasPreview, regenerateFeatureImageForFile } = useFileCache();
-        const { noteShortcutKeysByPath, addNoteShortcut, removeShortcut } = useShortcuts();
+        const shortcuts = useShortcuts();
+        const { noteShortcutKeysByPath, addNoteShortcut, removeShortcut } = shortcuts;
         const uiState = useUIState();
         const uiDispatch = useUIDispatch();
+
+        // Appends the full folder operations menu (rename, delete, new note, etc.) to a
+        // list-pane group header context menu. Used for folder group headers, including the
+        // empty-subfolder headers we render. ListPaneVirtualContent owns the Menu instance and
+        // adds its own merge-notes / manual-sort items after these.
+        const appendFolderGroupHeaderMenu = React.useCallback(
+            (menu: Menu, folder: TFolder) => {
+                buildFolderMenu({
+                    folder,
+                    menu,
+                    services: {
+                        app,
+                        plugin,
+                        isMobile,
+                        fileSystemOps,
+                        metadataService,
+                        tagOperations,
+                        propertyOperations,
+                        tagTreeService,
+                        propertyTreeService,
+                        commandQueue,
+                        shortcuts,
+                        visibility: { includeDescendantNotes, showHiddenItems }
+                    },
+                    settings,
+                    state: {
+                        selectionState,
+                        expandedFolders: expansionState.expandedFolders,
+                        expandedTags: expansionState.expandedTags,
+                        expandedProperties: expansionState.expandedProperties
+                    },
+                    dispatchers: {
+                        selectionDispatch,
+                        expansionDispatch,
+                        uiDispatch
+                    }
+                });
+            },
+            [
+                app,
+                plugin,
+                isMobile,
+                fileSystemOps,
+                metadataService,
+                tagOperations,
+                propertyOperations,
+                tagTreeService,
+                propertyTreeService,
+                commandQueue,
+                shortcuts,
+                includeDescendantNotes,
+                showHiddenItems,
+                settings,
+                selectionState,
+                expansionState.expandedFolders,
+                expansionState.expandedTags,
+                expansionState.expandedProperties,
+                selectionDispatch,
+                expansionDispatch,
+                uiDispatch
+            ]
+        );
         const isVerticalDualPane = !uiState.singlePane && uiState.effectiveDualPaneOrientation === 'vertical';
         const calendarPlacement = settings.calendarPlacement;
         const shouldRenderCalendarOverlay =
@@ -1479,6 +1546,7 @@ export const ListPane = React.memo(
                             noteShortcutKeysByPath={noteShortcutKeysByPath}
                             onToggleNoteShortcut={toggleNoteShortcut}
                             onNavigateToFolder={onNavigateToFolder}
+                            onAppendFolderGroupHeaderMenu={appendFolderGroupHeaderMenu}
                             folderDecorationModel={folderDecorationModel}
                             fileItemPillDecorationModel={fileItemPillDecorationModel}
                             fileItemPillOrderModel={fileItemPillOrderModel}

--- a/src/components/listPane/ListPaneVirtualContent.tsx
+++ b/src/components/listPane/ListPaneVirtualContent.tsx
@@ -145,6 +145,8 @@ interface ListPaneVirtualContentProps {
     noteShortcutKeysByPath: ReadonlyMap<string, string>;
     onToggleNoteShortcut: (file: TFile, shortcutKey: string | undefined) => Promise<void>;
     onNavigateToFolder: (folderPath: string, options?: NavigateToFolderOptions) => void;
+    /** Appends full folder-operation items to a group header context menu (folder group headers only). */
+    onAppendFolderGroupHeaderMenu?: (menu: Menu, folder: TFolder) => void;
     folderDecorationModel: FolderDecorationModel;
     fileItemPillDecorationModel: FileItemPillDecorationModel;
     fileItemPillOrderModel: FileItemPillOrderModel;
@@ -463,6 +465,7 @@ export function ListPaneVirtualContent({
     noteShortcutKeysByPath,
     onToggleNoteShortcut,
     onNavigateToFolder,
+    onAppendFolderGroupHeaderMenu,
     folderDecorationModel,
     fileItemPillDecorationModel,
     fileItemPillOrderModel,
@@ -723,8 +726,19 @@ export function ListPaneVirtualContent({
             const markdownGroupFiles = getMarkdownFilesInOrder(groupFiles);
             const menu = new Menu();
             let hasItems = false;
+
+            // Folder group header: prepend the full folder operations menu (rename, delete, new note, etc.)
+            const headerFolder = header.folderGroupHeaderTarget?.folder ?? null;
+            if (headerFolder && onAppendFolderGroupHeaderMenu) {
+                onAppendFolderGroupHeaderMenu(menu, headerFolder);
+                hasItems = true;
+            }
+
             if (markdownGroupFiles.length >= 2) {
-                hasItems = addMergeNotesMenuItem({
+                if (hasItems) {
+                    menu.addSeparator();
+                }
+                const addedMergeItem = addMergeNotesMenuItem({
                     menu,
                     app,
                     commandQueue,
@@ -734,6 +748,7 @@ export function ListPaneVirtualContent({
                     defaultOutputName: header.baseLabel || strings.modals.mergeNotes.outputNamePlaceholder,
                     title: strings.contextMenu.file.mergeNotesInGroup
                 });
+                hasItems = hasItems || addedMergeItem;
             }
 
             if (manualSortGroupHeaderPropertyKey && header.manualSortHeaderFilePath) {
@@ -761,7 +776,7 @@ export function ListPaneVirtualContent({
             event.stopPropagation();
             menu.showAtMouseEvent(event.nativeEvent);
         },
-        [app, commandQueue, fileSystemOps, manualSortGroupHeaderPropertyKey, metadataService]
+        [app, commandQueue, fileSystemOps, manualSortGroupHeaderPropertyKey, metadataService, onAppendFolderGroupHeaderMenu]
     );
 
     const handleListMouseMove = useCallback(
@@ -847,7 +862,7 @@ export function ListPaneVirtualContent({
                     <div className="nn-empty-state">
                         <div className="nn-empty-message">{strings.listPane.emptyStateNoSelection}</div>
                     </div>
-                ) : hasNoFiles ? (
+                ) : hasNoFiles && !listItems.some(item => item.type === ListPaneItemType.HEADER && item.headerKind === 'folder') ? (
                     <div className="nn-empty-state">
                         <div className="nn-empty-message">{strings.listPane.emptyStateNoNotes}</div>
                     </div>

--- a/src/hooks/listPaneData/listItems.ts
+++ b/src/hooks/listPaneData/listItems.ts
@@ -25,6 +25,7 @@ import { strings } from '../../i18n';
 import { FILE_VISIBILITY, type FileVisibility } from '../../utils/fileTypeUtils';
 import { compareByAlphaSortOrder, getDateField, isDateSortOption, isPropertySortOption } from '../../utils/sortUtils';
 import { partitionPinnedFiles } from '../../utils/fileFinder';
+import { getFolderNote, type FolderNoteDetectionSettings } from '../../utils/folderNotes';
 import {
     formatManualSortGroupHeaderLabel,
     getCachedManualSortGroupHeader,
@@ -46,6 +47,7 @@ import type { ListPaneFolderPathSegment } from '../../types/virtualization';
 
 export interface ListPaneConfig {
     filterPinnedByFolder: boolean;
+    folderNoteSettings: FolderNoteDetectionSettings;
     folderGroupSortOrder: AlphaSortOrder;
     groupBy: ListNoteGroupingOption;
     pinnedGroupExpanded: boolean;
@@ -541,6 +543,52 @@ export function buildListItems({
             });
         });
 
+        // Add direct subfolders that have no files so they appear as empty folder headers
+        if (selectedFolder && selectionType === ItemType.FOLDER && baseFolderPath && Array.isArray(selectedFolder.children)) {
+            for (const child of selectedFolder.children) {
+                if (!(child instanceof TFolder)) {
+                    continue;
+                }
+                const groupKey = `folder:${child.path}`;
+                if (folderGroups.has(groupKey)) {
+                    continue;
+                }
+                folderGroups.set(groupKey, {
+                    label: child.name,
+                    sortLabel: child.name,
+                    files: [],
+                    isCurrentFolder: false,
+                    folderPath: normalizePath(child.path)
+                });
+            }
+        }
+
+        // Surface each folder's folder note at the top of its own group, so the current
+        // folder's note ends up at the top of the list and every subfolder note sits above
+        // that subfolder's other files. Only reorders notes already visible in the list
+        // (respects "hide folder note in list"); it never re-adds a hidden note.
+        if (selectionType === ItemType.FOLDER && listConfig.folderNoteSettings?.enableFolderNotes) {
+            for (const group of folderGroups.values()) {
+                const folder = group.isCurrentFolder
+                    ? selectedFolder
+                    : group.folderPath
+                      ? app.vault.getFolderByPath(group.folderPath)
+                      : null;
+                if (!(folder instanceof TFolder)) {
+                    continue;
+                }
+                const folderNote = getFolderNote(folder, listConfig.folderNoteSettings);
+                if (!folderNote) {
+                    continue;
+                }
+                const noteIndex = group.files.findIndex(file => file.path === folderNote.path);
+                if (noteIndex > 0) {
+                    group.files.splice(noteIndex, 1);
+                    group.files.unshift(folderNote);
+                }
+            }
+        }
+
         const orderedGroups = Array.from(folderGroups.entries())
             .map(([key, group]) => ({ key, ...group }))
             .sort((left, right) => {
@@ -563,7 +611,9 @@ export function buildListItems({
             ((listConfig.showCurrentFolderFilesAtBottom && (pinnedFiles.length > 0 || childFolderGroups.length > 0)) ||
                 (!listConfig.showCurrentFolderFilesAtBottom && pinnedFiles.length > 0));
         const renderFolderGroup = (group: (typeof orderedGroups)[number]): void => {
-            if (group.files.length === 0) {
+            // Empty current-folder group has nothing to render; empty child folders
+            // still render a header so empty subfolders appear in the list.
+            if (group.isCurrentFolder && group.files.length === 0) {
                 return;
             }
 

--- a/src/hooks/useListPaneData.ts
+++ b/src/hooks/useListPaneData.ts
@@ -46,6 +46,7 @@ import type { ActiveProfileState } from '../context/SettingsContext';
 import type { SearchProvider } from '../types/search';
 import type { PropertySelectionNodeId } from '../utils/propertyTree';
 import { getFilesForNavigationSelection } from '../utils/selectionUtils';
+import { getFolderNoteDetectionSettings } from '../utils/folderNotes';
 import { getListSortOverrideForSelection, isManualSortPropertyKey, resolveListSort } from '../utils/sortUtils';
 import { applyManualSortMarkdownOrder, getManualSortGroupHeaderPropertyKey } from '../utils/manualSort';
 import { getPropertyFieldsFromPropertyKeys } from '../utils/vaultProfiles';
@@ -183,6 +184,11 @@ export function useListPaneData({
         () => ({
             pinnedNotes: settings.pinnedNotes,
             filterPinnedByFolder: settings.filterPinnedByFolder,
+            folderNoteSettings: getFolderNoteDetectionSettings({
+                enableFolderNotes: settings.enableFolderNotes,
+                folderNoteName: settings.folderNoteName,
+                folderNoteNamePattern: settings.folderNoteNamePattern
+            }),
             pinnedGroupExpanded,
             showTags: settings.showTags,
             showFileTags: settings.showFileTags,
@@ -200,7 +206,10 @@ export function useListPaneData({
             settings.showCurrentFolderFilesAtBottom,
             settings.showFolderGroupPaths,
             settings.showFileTags,
-            settings.showTags
+            settings.showTags,
+            settings.enableFolderNotes,
+            settings.folderNoteName,
+            settings.folderNoteNamePattern
         ]
     );
 

--- a/src/services/FileSystemService.ts
+++ b/src/services/FileSystemService.ts
@@ -923,9 +923,11 @@ export class FileSystemOperations {
      * Renames a file with user-provided name
      * Shows input modal pre-filled with current basename
      * Preserves original file extension if not provided in new name
+     * If the file is a folder note, also renames the parent folder to match
      * @param file - The file to rename
+     * @param settings - Plugin settings (used for folder note sync)
      */
-    async renameFile(file: TFile): Promise<void> {
+    async renameFile(file: TFile, settings?: NotebookNavigatorSettings): Promise<void> {
         // Check if file is Excalidraw to handle composite extension
         const isExcalidraw = isExcalidrawFile(file);
         const extension = file.extension;
@@ -984,9 +986,29 @@ export class FileSystemOperations {
                 }
 
                 try {
-                    const parentPath = file.parent?.path ?? '/';
+                    const parentFolder = file.parent;
+                    const parentPath = parentFolder?.path ?? '/';
                     const newPath = buildPathInFolder(parentPath, finalFileName);
                     await this.app.fileManager.renameFile(file, newPath);
+
+                    // If the renamed file was a folder note, rename the parent folder too
+                    if (
+                        settings?.enableFolderNotes &&
+                        parentFolder instanceof TFolder &&
+                        parentFolder.path !== '/' &&
+                        isFolderNote(file, parentFolder, getFolderNoteDetectionSettings(settings))
+                    ) {
+                        const newBaseName = isExcalidraw
+                            ? stripExcalidrawSuffix(finalFileName.replace(/\.[^.]+$/, ''))
+                            : finalFileName.replace(/\.[^.]+$/, '');
+                        if (newBaseName && newBaseName !== parentFolder.name) {
+                            const grandParentPath = parentFolder.parent?.path ?? '/';
+                            const newFolderPath = buildPathInFolder(grandParentPath, newBaseName);
+                            const previousFolderPath = parentFolder.path;
+                            await this.app.fileManager.renameFile(parentFolder, newFolderPath);
+                            await this.folderPathSettingsSync.syncHiddenFolderPathChange(previousFolderPath, newFolderPath);
+                        }
+                    }
                 } catch (error) {
                     this.notifyError(strings.fileSystem.errors.renameFile, error);
                 }

--- a/src/services/commands/registerNavigatorCommands.ts
+++ b/src/services/commands/registerNavigatorCommands.ts
@@ -1252,7 +1252,7 @@ export default function registerNavigatorCommands(plugin: NotebookNavigatorPlugi
                 return true;
             }
 
-            runAsyncAction(() => fileSystemOps.renameFile(folderNote));
+            runAsyncAction(() => fileSystemOps.renameFile(folderNote, plugin.settings));
             return true;
         }
     });

--- a/src/utils/contextMenu/fileMenuBuilder.ts
+++ b/src/utils/contextMenu/fileMenuBuilder.ts
@@ -523,7 +523,7 @@ export function buildFileMenu(params: FileMenuBuilderParams): void {
                   : strings.contextMenu.file.renameFile;
             const iconId = isFolderNoteFile ? 'lucide-unlink' : 'lucide-pencil';
             setAsyncOnClick(item.setTitle(title).setIcon(iconId), async () => {
-                await fileSystemOps.renameFile(file);
+                await fileSystemOps.renameFile(file, settings);
             });
         });
 


### PR DESCRIPTION
### What was done

Improves folder notes in the list pane:

- syncing when renaming a folder, automatically renames the file
- Showing empty folders without files, to be able to create files in those folders
- folder note is pinned to the top for navigation convenience
- Adding a context menu, for creating files and various folder operations
<details>
<summary>Imgs</summary>

<img width="876" height="372" alt="изображение" src="https://github.com/user-attachments/assets/5234083f-c8fc-455b-add5-e8da9893c8c4" />
<img width="1001" height="243" alt="изображение" src="https://github.com/user-attachments/assets/9c1d2c4e-56d4-47b6-97c3-a31d576ea925" />
<img width="1045" height="689" alt="изображение" src="https://github.com/user-attachments/assets/84337c7a-1823-432a-8e49-fc00ee3e2963" />
</details>


### Changes

- `ListPane.tsx` - `appendFolderGroupHeaderMenu` callback
- `src/hooks/listPaneData/listItems.ts`, `src/hooks/useListPaneData.ts` - empty folders, folder note at top
- `src/services/FileSystemService.ts` - `renameFile(file, settings)` with sync
- `src/utils/contextMenu/fileMenuBuilder.ts` - support for new rename signature
- `src/services/commands/registerNavigatorCommands.ts` - command registration

