### PR TITLE
feat: unified Appearance modal with icon, color, and background tabs

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -536,7 +536,20 @@ export const STRINGS_EN = {
             removeRecentColor: 'Remove color',
             apply: 'Apply',
             hexLabel: 'HEX',
-            rgbLabel: 'RGBA'
+            rgbLabel: 'RGBA',
+            saturationValueArea: 'Saturation and brightness',
+            hueSlider: 'Hue',
+            alphaSlider: 'Transparency'
+        },
+        appearance: {
+            menuTitle: 'Change appearance',
+            tabIcon: 'Icon',
+            tabColor: 'Color',
+            tabBackground: 'Background',
+            resetIcon: 'Remove icon',
+            resetColor: 'Remove color',
+            resetBackground: 'Remove background',
+            apply: 'Apply'
         },
         selectVaultProfile: {
             title: 'Select vault profile',

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -538,7 +538,20 @@ export const STRINGS_RU = {
             removeRecentColor: 'Удалить цвет',
             apply: 'Применить',
             hexLabel: 'HEX',
-            rgbLabel: 'RGBA'
+            rgbLabel: 'RGBA',
+            saturationValueArea: 'Насыщенность и яркость',
+            hueSlider: 'Оттенок',
+            alphaSlider: 'Прозрачность'
+        },
+        appearance: {
+            menuTitle: 'Изменить оформление',
+            tabIcon: 'Иконка',
+            tabColor: 'Цвет',
+            tabBackground: 'Фон',
+            resetIcon: 'Убрать иконку',
+            resetColor: 'Убрать цвет',
+            resetBackground: 'Убрать фон',
+            apply: 'Применить'
         },
         selectVaultProfile: {
             title: 'Выбор профиля хранилища',

--- a/src/modals/AppearanceModal.ts
+++ b/src/modals/AppearanceModal.ts
@@ -1,0 +1,368 @@
+/*
+ * Notebook Navigator - Plugin for Obsidian
+ * Copyright (c) 2025-2026 Johan Sanneblad
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { App, Modal, setIcon } from 'obsidian';
+import { strings } from '../i18n';
+import { ItemType } from '../types';
+import { MetadataService } from '../services/MetadataService';
+import { getIconService } from '../services/icons';
+import { addAsyncEventListener } from '../utils/domEventListeners';
+import { ColorPickerModal } from './ColorPickerModal';
+import { IconPickerModal } from './IconPickerModal';
+
+type AppearanceItemType =
+    | typeof ItemType.FOLDER
+    | typeof ItemType.TAG
+    | typeof ItemType.PROPERTY
+    | typeof ItemType.FILE;
+
+/** Configuration for a single editable aspect (color or background) */
+export interface AppearanceColorAspect {
+    initial: string | null;
+    apply: (value: string | null) => Promise<void>;
+}
+
+/** Configuration for the icon aspect */
+export interface AppearanceIconAspect {
+    initial: string | null;
+    apply: (iconId: string | null) => Promise<void>;
+}
+
+export interface AppearanceModalParams {
+    title: string;
+    metadataService: MetadataService;
+    itemPath: string;
+    itemType: AppearanceItemType;
+    icon?: AppearanceIconAspect;
+    color?: AppearanceColorAspect;
+    background?: AppearanceColorAspect;
+}
+
+interface AppearanceTab {
+    id: string;
+    button: HTMLElement;
+    panel: HTMLElement;
+}
+
+/**
+ * Unified appearance editor combining icon, color and background pickers into a
+ * single tabbed dialog. Selecting/editing on a tab only stages the change; the
+ * dialog stays open until the user clicks Apply, which commits every staged aspect.
+ */
+export class AppearanceModal extends Modal {
+    private params: AppearanceModalParams;
+    private iconService = getIconService();
+    private iconView?: IconPickerModal;
+    private colorView?: ColorPickerModal;
+    private backgroundView?: ColorPickerModal;
+    private tabs: AppearanceTab[] = [];
+    private activeTabId: string | null = null;
+    private domDisposers: (() => void)[] = [];
+    private previewItem!: HTMLDivElement;
+    private previewIconEl!: HTMLSpanElement;
+
+    constructor(app: App, params: AppearanceModalParams) {
+        super(app);
+        this.params = params;
+    }
+
+    onOpen() {
+        const { contentEl } = this;
+        contentEl.empty();
+        this.modalEl.addClass('nn-appearance-modal');
+
+        // Header doubles as a live preview of the item with the staged appearance
+        const header = contentEl.createDiv('nn-appearance-header');
+        const preview = header.createDiv('nn-appearance-preview');
+        this.previewItem = preview.createDiv('nn-appearance-preview-item');
+        this.previewIconEl = this.previewItem.createSpan('nn-appearance-preview-icon');
+        this.previewItem.createSpan({ cls: 'nn-appearance-preview-name', text: this.params.title });
+
+        const tabBar = contentEl.createDiv('nn-appearance-tabs');
+        tabBar.setAttribute('role', 'tablist');
+
+        const body = contentEl.createDiv('nn-appearance-body');
+
+        if (this.params.icon) {
+            this.addIconTab(tabBar, body, this.params.icon);
+        }
+        if (this.params.color) {
+            this.addColorTab(tabBar, body, this.params.color, 'color', strings.modals.appearance.tabColor, strings.modals.appearance.resetColor);
+        }
+        if (this.params.background) {
+            this.addColorTab(
+                tabBar,
+                body,
+                this.params.background,
+                'background',
+                strings.modals.appearance.tabBackground,
+                strings.modals.appearance.resetBackground
+            );
+        }
+
+        const footer = contentEl.createDiv('nn-appearance-footer');
+        const cancelButton = footer.createEl('button', { text: strings.common.cancel });
+        this.domDisposers.push(addAsyncEventListener(cancelButton, 'click', () => this.close()));
+        const applyButton = footer.createEl('button', { text: strings.modals.appearance.apply, cls: 'mod-cta' });
+        this.domDisposers.push(addAsyncEventListener(applyButton, 'click', () => this.applyAll()));
+
+        if (this.tabs.length > 0) {
+            this.setActiveTab(this.tabs[0].id);
+        }
+
+        this.renderPreview();
+    }
+
+    /**
+     * Updates the header preview to reflect the currently staged icon, text color
+     * and background, mirroring how the item will look in the navigator.
+     */
+    private renderPreview(): void {
+        if (!this.previewItem) {
+            return;
+        }
+
+        let effectiveIcon: string | null = null;
+        if (this.params.icon && this.iconView) {
+            effectiveIcon = this.iconView.isIconCleared() ? null : (this.iconView.getStagedIcon() ?? null);
+        }
+
+        let effectiveColor: string | null = null;
+        if (this.params.color && this.colorView) {
+            effectiveColor = this.colorView.isCleared()
+                ? null
+                : this.colorView.isTouched()
+                  ? this.colorView.getColor()
+                  : this.params.color.initial;
+        }
+
+        let effectiveBackground: string | null = null;
+        if (this.params.background && this.backgroundView) {
+            effectiveBackground = this.backgroundView.isCleared()
+                ? null
+                : this.backgroundView.isTouched()
+                  ? this.backgroundView.getColor()
+                  : this.params.background.initial;
+        }
+
+        this.previewIconEl.empty();
+        if (effectiveIcon) {
+            this.iconService.renderIcon(this.previewIconEl, effectiveIcon);
+            this.previewIconEl.removeClass('nn-appearance-preview-icon-empty');
+        } else {
+            this.previewIconEl.addClass('nn-appearance-preview-icon-empty');
+        }
+
+        if (effectiveColor) {
+            this.previewItem.style.setProperty('--nn-preview-fg', effectiveColor);
+        } else {
+            this.previewItem.style.removeProperty('--nn-preview-fg');
+        }
+
+        if (effectiveBackground) {
+            this.previewItem.style.setProperty('--nn-preview-bg', effectiveBackground);
+        } else {
+            this.previewItem.style.removeProperty('--nn-preview-bg');
+        }
+    }
+
+    /**
+     * Creates a tab button + panel, registers the activation handler, and returns the panel.
+     */
+    private createTab(tabBar: HTMLElement, body: HTMLElement, id: string, label: string, iconName: string): HTMLElement {
+        const button = tabBar.createDiv({ cls: 'nn-appearance-tab' });
+        button.setAttribute('role', 'tab');
+        const tabIcon = button.createSpan('nn-appearance-tab-icon');
+        setIcon(tabIcon, iconName);
+        button.createSpan({ cls: 'nn-appearance-tab-label', text: label });
+
+        const panel = body.createDiv('nn-appearance-panel nn-appearance-panel-hidden');
+
+        this.tabs.push({ id, button, panel });
+        this.domDisposers.push(addAsyncEventListener(button, 'click', () => this.setActiveTab(id)));
+        return panel;
+    }
+
+    private addIconTab(tabBar: HTMLElement, body: HTMLElement, cfg: AppearanceIconAspect): void {
+        const panel = this.createTab(tabBar, body, 'icon', strings.modals.appearance.tabIcon, 'lucide-image');
+
+        const resetRow = panel.createDiv('nn-appearance-reset-row');
+        const resetButton = this.createResetButton(resetRow, strings.modals.appearance.resetIcon);
+
+        const view = new IconPickerModal(this.app, this.params.metadataService, this.params.itemPath, this.params.itemType, {
+            currentIconId: cfg.initial ?? null,
+            disableMetadataUpdates: true
+        });
+        this.iconView = view;
+
+        const pickerHost = panel.createDiv('nn-appearance-picker-host');
+        view.mountEmbedded(pickerHost, {
+            onSelect: iconId => {
+                this.setResetActive(resetButton, iconId === null);
+                this.renderPreview();
+            }
+        });
+
+        this.domDisposers.push(
+            addAsyncEventListener(resetButton, 'click', () => {
+                view.clearSelection();
+                this.setResetActive(resetButton, true);
+                this.renderPreview();
+            })
+        );
+    }
+
+    private addColorTab(
+        tabBar: HTMLElement,
+        body: HTMLElement,
+        cfg: AppearanceColorAspect,
+        id: 'color' | 'background',
+        label: string,
+        resetLabel: string
+    ): void {
+        const iconName = id === 'background' ? 'lucide-paint-bucket' : 'lucide-palette';
+        const panel = this.createTab(tabBar, body, id, label, iconName);
+
+        const resetRow = panel.createDiv('nn-appearance-reset-row');
+        const resetButton = this.createResetButton(resetRow, resetLabel);
+
+        const view = new ColorPickerModal(this.app, {
+            title: this.params.title,
+            initialColor: cfg.initial,
+            settingsProvider: this.params.metadataService.getSettingsProvider(),
+            // Unused in embedded mode; the host commits the value via applyAll()
+            onChooseColor: () => undefined
+        });
+
+        if (id === 'background') {
+            this.backgroundView = view;
+        } else {
+            this.colorView = view;
+        }
+
+        const pickerHost = panel.createDiv('nn-appearance-picker-host');
+        view.mountInto(pickerHost, this.scope, {
+            onUserEdit: () => {
+                this.setResetActive(resetButton, false);
+                this.renderPreview();
+            }
+        });
+
+        this.domDisposers.push(
+            addAsyncEventListener(resetButton, 'click', () => {
+                view.markCleared();
+                this.setResetActive(resetButton, true);
+                this.renderPreview();
+            })
+        );
+    }
+
+    private createResetButton(container: HTMLElement, label: string): HTMLButtonElement {
+        const button = container.createEl('button', { cls: 'nn-appearance-reset-button', text: label });
+        return button;
+    }
+
+    private setResetActive(button: HTMLElement, active: boolean): void {
+        button.toggleClass('nn-appearance-reset-active', active);
+    }
+
+    private setActiveTab(id: string): void {
+        this.activeTabId = id;
+        this.tabs.forEach(tab => {
+            const isActive = tab.id === id;
+            tab.button.toggleClass('nn-active', isActive);
+            tab.panel.toggleClass('nn-appearance-panel-hidden', !isActive);
+        });
+    }
+
+    /**
+     * Commits every staged aspect, then closes the dialog.
+     */
+    private async applyAll(): Promise<void> {
+        const actions: Promise<void>[] = [];
+
+        if (this.params.icon && this.iconView) {
+            const action = this.collectIconAction(this.iconView, this.params.icon);
+            if (action) {
+                actions.push(action);
+            }
+        }
+        if (this.params.color && this.colorView) {
+            const action = this.collectColorAction(this.colorView, this.params.color);
+            if (action) {
+                actions.push(action);
+            }
+        }
+        if (this.params.background && this.backgroundView) {
+            const action = this.collectColorAction(this.backgroundView, this.params.background);
+            if (action) {
+                actions.push(action);
+            }
+        }
+
+        await Promise.all(actions);
+        this.close();
+    }
+
+    private collectIconAction(view: IconPickerModal, cfg: AppearanceIconAspect): Promise<void> | null {
+        if (view.isIconCleared()) {
+            return cfg.initial ? cfg.apply(null) : null;
+        }
+        const staged = view.getStagedIcon();
+        const initial = cfg.initial ?? undefined;
+        if (staged !== undefined && staged !== initial) {
+            return cfg.apply(staged);
+        }
+        return null;
+    }
+
+    private collectColorAction(view: ColorPickerModal, cfg: AppearanceColorAspect): Promise<void> | null {
+        if (view.isCleared()) {
+            return cfg.initial ? cfg.apply(null) : null;
+        }
+        if (view.isTouched()) {
+            view.commitRecentColor();
+            return cfg.apply(view.getColor());
+        }
+        return null;
+    }
+
+    onClose() {
+        const { contentEl } = this;
+        this.iconView?.detach();
+        this.colorView?.detach();
+        this.backgroundView?.detach();
+        this.iconView = undefined;
+        this.colorView = undefined;
+        this.backgroundView = undefined;
+        this.tabs = [];
+        this.activeTabId = null;
+        if (this.domDisposers.length) {
+            this.domDisposers.forEach(dispose => {
+                try {
+                    dispose();
+                } catch (e) {
+                    console.error('Error disposing appearance modal listener:', e);
+                }
+            });
+            this.domDisposers = [];
+        }
+        contentEl.empty();
+        this.modalEl.removeClass('nn-appearance-modal');
+    }
+}

--- a/src/modals/ColorPickerModal.ts
+++ b/src/modals/ColorPickerModal.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { App, Modal, setIcon } from 'obsidian';
+import { App, Modal, Scope, setIcon } from 'obsidian';
 import { strings } from '../i18n';
 import {
     DEFAULT_CUSTOM_COLOR,
@@ -34,9 +34,9 @@ import { ConfirmModal } from './ConfirmModal';
 
 const DEFAULT_COLOR = '#3b82f6';
 
-type ColorChannel = 'r' | 'g' | 'b' | 'a';
-
 type RGBAValues = { r: number; g: number; b: number; a: number };
+
+type HSVValues = { h: number; s: number; v: number };
 
 /** Palette display mode: default (read-only preset colors) or custom (user-editable colors) */
 type PaletteMode = 'default' | 'custom';
@@ -70,8 +70,18 @@ export class ColorPickerModal extends Modal {
     private hexInput!: HTMLInputElement;
     private previewCurrent!: HTMLDivElement;
     private previewNew!: HTMLDivElement;
-    private channelSliders!: Record<ColorChannel, HTMLInputElement>;
-    private channelValues!: Record<ColorChannel, HTMLSpanElement>;
+    private svArea!: HTMLDivElement;
+    private svThumb!: HTMLDivElement;
+    private hueSlider!: HTMLDivElement;
+    private hueThumb!: HTMLDivElement;
+    private alphaSlider!: HTMLDivElement;
+    private alphaThumb!: HTMLDivElement;
+    // HSV/alpha working state for the visual picker. Hue is preserved across
+    // achromatic colors so dragging brightness/saturation to gray and back keeps it.
+    private hue = 0;
+    private saturation = 0;
+    private value = 0;
+    private alpha = 255;
     private recentColorsContainer!: HTMLDivElement;
     private userColorsContainer!: HTMLDivElement;
     private userColorDots: HTMLDivElement[] = [];
@@ -92,6 +102,15 @@ export class ColorPickerModal extends Modal {
     private domDisposers: (() => void)[] = [];
     private dragGhostManager: DragGhostManager;
     private pendingPaletteSwitchHandle: number | null = null;
+    // Embedded mode: the picker surface is hosted inside another modal (AppearanceModal).
+    // In this mode there is no header or Apply/Cancel footer, and the host commits the value.
+    private embedded = false;
+    private onUserEdit?: () => void;
+    private cleared = false;
+    // True only while building the initial UI, so the first programmatic color
+    // load is not mistaken for a user edit.
+    private building = false;
+    private touched = false;
 
     /** Returns the last used palette mode across modal instances */
     public static getLastPaletteMode(): PaletteMode {
@@ -146,8 +165,56 @@ export class ColorPickerModal extends Modal {
 
         this.attachCloseButtonHandler();
 
+        this.buildPickerInto(contentEl, this.scope);
+
+        // Action buttons
+        const buttonContainer = contentEl.createDiv('nn-color-button-container');
+
+        // Cancel/restore button
+        const restoreDefaultText = strings.common.restoreDefault;
+        const cancelRemoveButton = buttonContainer.createEl('button', {
+            text: this.currentColor ? restoreDefaultText : strings.common.cancel
+        });
+        this.domDisposers.push(
+            addAsyncEventListener(cancelRemoveButton, 'click', () => {
+                if (this.currentColor) {
+                    return this.restoreDefaultColor();
+                }
+                this.close();
+                return undefined;
+            })
+        );
+
+        // Apply color button
+        const applyButton = buttonContainer.createEl('button', {
+            text: strings.modals.colorPicker.apply,
+            cls: 'mod-cta'
+        });
+        this.domDisposers.push(addAsyncEventListener(applyButton, 'click', () => this.applyColor()));
+    }
+
+    /**
+     * Mounts the color editing surface into an external container (used by AppearanceModal).
+     * No header or Apply/Cancel footer is created; the host commits the value via getColor().
+     */
+    mountInto(container: HTMLElement, scope: Scope, options: { onUserEdit?: () => void } = {}) {
+        this.embedded = true;
+        this.onUserEdit = options.onUserEdit;
+        this.buildPickerInto(container, scope);
+    }
+
+    /** Returns true if the user has changed the color since mounting (embedded mode) */
+    isTouched(): boolean {
+        return this.touched;
+    }
+
+    /**
+     * Builds the color editing surface (preview, palette, picker area, hex, recent) into a container.
+     */
+    private buildPickerInto(root: HTMLElement, scope: Scope) {
+        this.building = true;
         // Two-column layout
-        const mainContent = contentEl.createDiv('nn-color-picker-content');
+        const mainContent = root.createDiv('nn-color-picker-content');
 
         // Left column
         const leftColumn = mainContent.createDiv('nn-color-picker-left');
@@ -278,38 +345,46 @@ export class ColorPickerModal extends Modal {
         });
         this.hexInput.setAttribute('enterkeyhint', 'done');
 
-        // RGB sliders section
-        const rgbSection = rightColumn.createDiv('nn-rgb-section');
-        rgbSection.createDiv({ text: strings.modals.colorPicker.rgbLabel, cls: 'nn-rgb-title' });
-        this.channelSliders = {} as Record<ColorChannel, HTMLInputElement>;
-        this.channelValues = {} as Record<ColorChannel, HTMLSpanElement>;
+        // Visual color picker: 2D saturation/brightness area plus hue and alpha sliders
+        const colorAreaSection = rightColumn.createDiv('nn-color-area-section');
 
-        (['r', 'g', 'b', 'a'] as const).forEach(channel => {
-            const sliderRow = rgbSection.createDiv('nn-rgb-row');
-            sliderRow.createSpan({
-                text: channel.toUpperCase(),
-                cls: 'nn-rgb-label'
-            });
+        this.svArea = colorAreaSection.createDiv('nn-sv-area');
+        this.svArea.setAttribute('aria-label', strings.modals.colorPicker.saturationValueArea);
+        this.svThumb = this.svArea.createDiv('nn-sv-thumb');
+        this.attachPointerArea(
+            this.svArea,
+            (x, y) => {
+                this.saturation = x;
+                this.value = 1 - y;
+                this.commitHsvColor();
+            },
+            this.domDisposers
+        );
 
-            const slider = sliderRow.createEl('input', {
-                type: 'range',
-                cls: 'nn-rgb-slider',
-                attr: {
-                    'aria-label': `${channel.toUpperCase()} value`,
-                    min: '0',
-                    max: '255'
-                }
-            });
-            slider.classList.add(`nn-rgb-slider-${channel}`);
+        this.hueSlider = colorAreaSection.createDiv('nn-color-slider nn-hue-slider');
+        this.hueSlider.setAttribute('aria-label', strings.modals.colorPicker.hueSlider);
+        this.hueThumb = this.hueSlider.createDiv('nn-slider-thumb');
+        this.attachPointerArea(
+            this.hueSlider,
+            x => {
+                this.hue = x * 360;
+                this.commitHsvColor();
+            },
+            this.domDisposers
+        );
 
-            const value = sliderRow.createSpan({
-                cls: 'nn-rgb-value',
-                text: '0'
-            });
-
-            this.channelSliders[channel] = slider;
-            this.channelValues[channel] = value;
-        });
+        this.alphaSlider = colorAreaSection.createDiv('nn-color-slider nn-alpha-slider nn-checkerboard');
+        this.alphaSlider.setAttribute('aria-label', strings.modals.colorPicker.alphaSlider);
+        this.alphaSlider.createDiv('nn-alpha-gradient');
+        this.alphaThumb = this.alphaSlider.createDiv('nn-slider-thumb');
+        this.attachPointerArea(
+            this.alphaSlider,
+            x => {
+                this.alpha = Math.round(x * 255);
+                this.commitHsvColor();
+            },
+            this.domDisposers
+        );
 
         // Recent colors section
         const recentSection = rightColumn.createDiv('nn-recent-section');
@@ -330,40 +405,15 @@ export class ColorPickerModal extends Modal {
 
         this.recentColorsContainer = recentSection.createDiv('nn-recent-colors');
 
-        // Action buttons
-        const buttonContainer = contentEl.createDiv('nn-color-button-container');
-
-        // Cancel/restore button
-        const restoreDefaultText = strings.common.restoreDefault;
-        const cancelRemoveButton = buttonContainer.createEl('button', {
-            text: this.currentColor ? restoreDefaultText : strings.common.cancel
-        });
-        this.domDisposers.push(
-            addAsyncEventListener(cancelRemoveButton, 'click', () => {
-                if (this.currentColor) {
-                    return this.restoreDefaultColor();
-                }
-                this.close();
-                return undefined;
-            })
-        );
-
-        // Apply color button
-        const applyButton = buttonContainer.createEl('button', {
-            text: strings.modals.colorPicker.apply,
-            cls: 'mod-cta'
-        });
-        this.domDisposers.push(addAsyncEventListener(applyButton, 'click', () => this.applyColor()));
-
         // Set up event handlers
-        this.setupEventHandlers();
-        this.registerKeyboardShortcuts();
+        this.registerKeyboardShortcuts(scope);
         this.loadRecentColors();
         this.loadCustomColors();
         this.updatePaletteToggleState();
         this.renderUserColors();
         this.updatePresetButtonsVisibility();
         this.updateFromHex(this.selectedColor);
+        this.building = false;
 
         // Hex input real-time validation and update
         this.domDisposers.push(
@@ -380,13 +430,31 @@ export class ColorPickerModal extends Modal {
         );
     }
 
+    /** Returns the currently selected color as a hex string */
+    getColor(): string {
+        return this.selectedColor;
+    }
+
+    /** Marks the value for removal when the host commits */
+    markCleared(): void {
+        this.cleared = true;
+    }
+
+    /** Returns true if the value has been flagged for removal */
+    isCleared(): boolean {
+        return this.cleared;
+    }
+
+    /** Persists the current color into the recent colors history */
+    commitRecentColor(): void {
+        this.saveToRecentColors(this.selectedColor);
+    }
+
     /**
-     * Called when the modal is closed
+     * Releases listeners and persists pending custom-palette edits.
+     * Shared by standalone onClose and the embedding host.
      */
-    onClose() {
-        const { contentEl } = this;
-        contentEl.empty();
-        this.modalEl.removeClass('nn-color-picker-modal');
+    detach(): void {
         if (this.customColorsDirty) {
             this.settingsProvider.settings.userColors = [...this.customColors];
             runAsyncAction(() => this.settingsProvider.saveSettingsAndUpdate());
@@ -412,6 +480,16 @@ export class ColorPickerModal extends Modal {
         }
     }
 
+    /**
+     * Called when the modal is closed
+     */
+    onClose() {
+        const { contentEl } = this;
+        contentEl.empty();
+        this.modalEl.removeClass('nn-color-picker-modal');
+        this.detach();
+    }
+
     // Attaches event handlers to the modal close button to ensure proper modal closure
     private attachCloseButtonHandler() {
         const closeButton = this.modalEl.querySelector<HTMLElement>('.modal-close-button');
@@ -430,27 +508,58 @@ export class ColorPickerModal extends Modal {
     }
 
     /**
-     * Set up event handlers for sliders
+     * Attaches pointer drag handling to a track element, emitting normalized
+     * [0,1] coordinates on press and drag. Pointer capture keeps the drag alive
+     * even when the cursor leaves the element.
      */
-    private setupEventHandlers() {
-        // RGB slider handlers
-        (Object.keys(this.channelSliders) as ColorChannel[]).forEach(channel => {
-            const slider = this.channelSliders[channel];
-            this.domDisposers.push(
-                addAsyncEventListener(slider, 'input', () => {
-                    if (!this.isUpdating) {
-                        this.updateFromRGB();
-                    }
-                })
-            );
-        });
+    private attachPointerArea(
+        element: HTMLElement,
+        onChange: (xRatio: number, yRatio: number) => void,
+        disposers: (() => void)[]
+    ) {
+        let dragging = false;
+
+        const emit = (event: PointerEvent) => {
+            const rect = element.getBoundingClientRect();
+            const x = rect.width > 0 ? (event.clientX - rect.left) / rect.width : 0;
+            const y = rect.height > 0 ? (event.clientY - rect.top) / rect.height : 0;
+            onChange(Math.max(0, Math.min(1, x)), Math.max(0, Math.min(1, y)));
+        };
+
+        const stop = (event: PointerEvent) => {
+            if (!dragging) {
+                return;
+            }
+            dragging = false;
+            if (element.hasPointerCapture(event.pointerId)) {
+                element.releasePointerCapture(event.pointerId);
+            }
+        };
+
+        disposers.push(
+            addAsyncEventListener(element, 'pointerdown', event => {
+                dragging = true;
+                element.setPointerCapture(event.pointerId);
+                event.preventDefault();
+                emit(event);
+            })
+        );
+        disposers.push(
+            addAsyncEventListener(element, 'pointermove', event => {
+                if (dragging) {
+                    emit(event);
+                }
+            })
+        );
+        disposers.push(addAsyncEventListener(element, 'pointerup', stop));
+        disposers.push(addAsyncEventListener(element, 'pointercancel', stop));
     }
 
     /**
      * Register keyboard shortcuts for the modal
      */
-    private registerKeyboardShortcuts() {
-        this.scope.register([], 'Enter', event => {
+    private registerKeyboardShortcuts(scope: Scope) {
+        scope.register([], 'Enter', event => {
             if (activeDocument.activeElement === this.hexInput) {
                 event.preventDefault();
                 window.setTimeout(() => {
@@ -1195,51 +1304,145 @@ export class ColorPickerModal extends Modal {
         if (rgba) {
             normalizedHex = this.rgbaToHex(rgba);
             this.selectedColor = normalizedHex;
+            this.alpha = rgba.a;
+
+            const hsv = this.rgbToHsv(rgba);
+            // Keep the previous hue for grayscale colors so the hue slider doesn't jump
+            if (hsv.s > 0 && hsv.v > 0) {
+                this.hue = hsv.h;
+            }
+            this.saturation = hsv.s;
+            this.value = hsv.v;
+
             this.applySwatchColor(this.previewNew, normalizedHex);
             if (syncInput) {
                 this.hexInput.value = normalizedHex.substring(1);
             }
 
-            this.channelSliders.r.value = rgba.r.toString();
-            this.channelSliders.g.value = rgba.g.toString();
-            this.channelSliders.b.value = rgba.b.toString();
-            this.channelSliders.a.value = rgba.a.toString();
-            this.channelValues.r.setText(rgba.r.toString());
-            this.channelValues.g.setText(rgba.g.toString());
-            this.channelValues.b.setText(rgba.b.toString());
-            this.channelValues.a.setText(rgba.a.toString());
+            this.renderColorControls();
         }
 
         this.isUpdating = false;
 
         if (normalizedHex) {
             this.updateActiveCustomColor(normalizedHex);
+            // A user-driven color change un-marks pending removal and notifies the host.
+            // The initial programmatic load (building) must not count as a user edit.
+            if (this.embedded && !this.building) {
+                this.cleared = false;
+                this.touched = true;
+                this.onUserEdit?.();
+            }
         }
     }
 
     /**
-     * Update from RGB slider values
+     * Builds a hex color from the current HSV/alpha state and applies it
      */
-    private updateFromRGB() {
-        const r = parseInt(this.channelSliders.r.value, 10) || 0;
-        const g = parseInt(this.channelSliders.g.value, 10) || 0;
-        const b = parseInt(this.channelSliders.b.value, 10) || 0;
-        const a = parseInt(this.channelSliders.a.value, 10) || 0;
+    private commitHsvColor() {
+        if (this.isUpdating) {
+            return;
+        }
+        this.updateFromHex(this.composeHsvColor(), { syncInput: true });
+    }
 
-        // Update value displays
-        this.channelValues.r.setText(r.toString());
-        this.channelValues.g.setText(g.toString());
-        this.channelValues.b.setText(b.toString());
-        this.channelValues.a.setText(a.toString());
+    /**
+     * Combines current hue, saturation, value and alpha into a hex string
+     */
+    private composeHsvColor(): string {
+        const rgb = this.hsvToRgb(this.hue, this.saturation, this.value);
+        return this.rgbaToHex({ ...rgb, a: this.alpha });
+    }
 
-        const rgba: RGBAValues = { r, g, b, a };
-        const hex = this.rgbaToHex(rgba);
-        this.selectedColor = hex;
+    /**
+     * Positions the picker thumbs and refreshes the gradients to match current state
+     */
+    private renderColorControls() {
+        if (!this.svArea) {
+            return;
+        }
 
-        // Update preview and hex input
-        this.applySwatchColor(this.previewNew, hex);
-        this.hexInput.value = hex.substring(1);
-        this.updateActiveCustomColor(hex);
+        const pureHue = this.rgbaToHex({ ...this.hsvToRgb(this.hue, 1, 1), a: 255 });
+        const opaque = this.rgbaToHex({ ...this.hsvToRgb(this.hue, this.saturation, this.value), a: 255 });
+
+        this.svArea.style.setProperty('--nn-sv-hue', pureHue);
+        this.svThumb.style.left = `${this.saturation * 100}%`;
+        this.svThumb.style.top = `${(1 - this.value) * 100}%`;
+        this.svThumb.style.setProperty('--nn-thumb-color', opaque);
+
+        this.hueThumb.style.left = `${(this.hue / 360) * 100}%`;
+
+        this.alphaSlider.style.setProperty('--nn-alpha-color', opaque);
+        this.alphaThumb.style.left = `${(this.alpha / 255) * 100}%`;
+    }
+
+    /**
+     * Converts an RGBA color to HSV (hue 0-360, saturation/value 0-1)
+     */
+    private rgbToHsv({ r, g, b }: RGBAValues): HSVValues {
+        const red = r / 255;
+        const green = g / 255;
+        const blue = b / 255;
+        const max = Math.max(red, green, blue);
+        const min = Math.min(red, green, blue);
+        const delta = max - min;
+
+        let h = 0;
+        if (delta !== 0) {
+            if (max === red) {
+                h = ((green - blue) / delta) % 6;
+            } else if (max === green) {
+                h = (blue - red) / delta + 2;
+            } else {
+                h = (red - green) / delta + 4;
+            }
+            h *= 60;
+            if (h < 0) {
+                h += 360;
+            }
+        }
+
+        const s = max === 0 ? 0 : delta / max;
+        return { h, s, v: max };
+    }
+
+    /**
+     * Converts HSV (hue 0-360, saturation/value 0-1) to an RGB color (0-255)
+     */
+    private hsvToRgb(h: number, s: number, v: number): { r: number; g: number; b: number } {
+        const chroma = v * s;
+        const sector = ((((h % 360) + 360) % 360) / 60);
+        const x = chroma * (1 - Math.abs((sector % 2) - 1));
+        const m = v - chroma;
+
+        let r1 = 0;
+        let g1 = 0;
+        let b1 = 0;
+        if (sector < 1) {
+            r1 = chroma;
+            g1 = x;
+        } else if (sector < 2) {
+            r1 = x;
+            g1 = chroma;
+        } else if (sector < 3) {
+            g1 = chroma;
+            b1 = x;
+        } else if (sector < 4) {
+            g1 = x;
+            b1 = chroma;
+        } else if (sector < 5) {
+            r1 = x;
+            b1 = chroma;
+        } else {
+            r1 = chroma;
+            b1 = x;
+        }
+
+        return {
+            r: Math.round((r1 + m) * 255),
+            g: Math.round((g1 + m) * 255),
+            b: Math.round((b1 + m) * 255)
+        };
     }
 
     /**

--- a/src/modals/IconPickerModal.ts
+++ b/src/modals/IconPickerModal.ts
@@ -86,6 +86,12 @@ export class IconPickerModal extends Modal {
     private removeButton: HTMLButtonElement | null = null;
     private providerLinkContainer: HTMLDivElement | null = null;
     private providerLinkEl: HTMLAnchorElement | null = null;
+    // Container the picker UI is built into. Defaults to contentEl; an embedding
+    // host (AppearanceModal) supplies its own container via mountEmbedded().
+    private rootEl!: HTMLElement;
+    private embedded = false;
+    private onSelectCallback?: (iconId: string | null) => void;
+    private cleared = false;
 
     public static getLastUsedProvider(): string | null {
         return IconPickerModal.lastUsedProvider;
@@ -120,6 +126,7 @@ export class IconPickerModal extends Modal {
         const { contentEl } = this;
         contentEl.empty();
         this.modalEl.addClass('nn-icon-picker-modal');
+        this.rootEl = contentEl;
         this.cleanupVaultRecentIcons();
 
         // Header showing the folder/tag name
@@ -147,25 +154,9 @@ export class IconPickerModal extends Modal {
         })();
         header.createEl('h3', { text: headerText });
 
-        // Create tabs for providers
-        this.createProviderTabs();
-
-        // Create search input
-        const searchContainer = contentEl.createDiv('nn-icon-search-container');
-        this.searchInput = searchContainer.createEl('input', {
-            type: 'text',
-            placeholder: strings.modals.iconPicker.searchPlaceholder,
-            cls: 'nn-icon-search-input'
-        });
-        this.searchInput.setAttribute('enterkeyhint', 'done');
-
         this.attachCloseButtonHandler();
 
-        // Create results container
-        this.resultsContainer = contentEl.createDiv('nn-icon-results-container');
-        this.domDisposers.push(addAsyncEventListener(this.resultsContainer, 'click', event => this.handleResultsClick(event)));
-        this.createProviderLinkRow();
-        this.updateProviderLink(this.currentProvider);
+        this.buildPickerBody();
 
         if (this.showRemoveButton) {
             const buttonContainer = contentEl.createDiv('nn-icon-button-container');
@@ -181,18 +172,6 @@ export class IconPickerModal extends Modal {
             this.domDisposers.push(addAsyncEventListener(removeButton, 'click', () => this.removeIcon()));
         }
 
-        // Search input with debouncing
-        this.domDisposers.push(
-            addAsyncEventListener(this.searchInput, 'input', () => {
-                if (this.searchDebounceTimer) {
-                    window.clearTimeout(this.searchDebounceTimer);
-                }
-                this.searchDebounceTimer = window.setTimeout(() => {
-                    this.updateResults();
-                }, TIMEOUTS.DEBOUNCE_KEYBOARD);
-            })
-        );
-
         // Set up keyboard navigation
         this.setupKeyboardNavigation();
 
@@ -206,6 +185,56 @@ export class IconPickerModal extends Modal {
 
         // Show initial results
         this.updateResults();
+    }
+
+    /**
+     * Mounts the icon picker UI (provider tabs, search, results) into an external
+     * container for use inside AppearanceModal. No header, remove button, keyboard
+     * navigation or metadata persistence; selecting an icon stages it via onSelect.
+     */
+    mountEmbedded(container: HTMLElement, options: { onSelect?: (iconId: string | null) => void } = {}): void {
+        this.embedded = true;
+        this.rootEl = container;
+        this.onSelectCallback = options.onSelect;
+        this.cleanupVaultRecentIcons();
+        this.buildPickerBody();
+        this.updateResults();
+    }
+
+    /**
+     * Builds the provider tabs, search field, results container and provider link
+     * into rootEl, and wires the search input. Shared by standalone and embedded modes.
+     */
+    private buildPickerBody(): void {
+        // Create tabs for providers
+        this.createProviderTabs();
+
+        // Create search input
+        const searchContainer = this.rootEl.createDiv('nn-icon-search-container');
+        this.searchInput = searchContainer.createEl('input', {
+            type: 'text',
+            placeholder: strings.modals.iconPicker.searchPlaceholder,
+            cls: 'nn-icon-search-input'
+        });
+        this.searchInput.setAttribute('enterkeyhint', 'done');
+
+        // Create results container
+        this.resultsContainer = this.rootEl.createDiv('nn-icon-results-container');
+        this.domDisposers.push(addAsyncEventListener(this.resultsContainer, 'click', event => this.handleResultsClick(event)));
+        this.createProviderLinkRow();
+        this.updateProviderLink(this.currentProvider);
+
+        // Search input with debouncing
+        this.domDisposers.push(
+            addAsyncEventListener(this.searchInput, 'input', () => {
+                if (this.searchDebounceTimer) {
+                    window.clearTimeout(this.searchDebounceTimer);
+                }
+                this.searchDebounceTimer = window.setTimeout(() => {
+                    this.updateResults();
+                }, TIMEOUTS.DEBOUNCE_KEYBOARD);
+            })
+        );
     }
 
     private async handleResultsClick(event: MouseEvent): Promise<void> {
@@ -239,7 +268,7 @@ export class IconPickerModal extends Modal {
     }
 
     private createProviderTabs() {
-        this.tabContainer = this.contentEl.createDiv('nn-icon-provider-tabs');
+        this.tabContainer = this.rootEl.createDiv('nn-icon-provider-tabs');
         this.tabContainer.setAttribute('role', 'tablist');
         this.providerTabs = [];
 
@@ -286,7 +315,7 @@ export class IconPickerModal extends Modal {
      * Creates the provider link row UI elements below the icon tabs
      */
     private createProviderLinkRow(): void {
-        this.providerLinkContainer = this.contentEl.createDiv('nn-icon-provider-link-row');
+        this.providerLinkContainer = this.rootEl.createDiv('nn-icon-provider-link-row');
         this.providerLinkEl = this.providerLinkContainer.createEl('a', { cls: 'nn-icon-provider-link' });
         this.providerLinkEl.setAttribute('target', '_blank');
         this.providerLinkEl.setAttribute('rel', 'noopener noreferrer');
@@ -628,6 +657,9 @@ export class IconPickerModal extends Modal {
 
         const iconItem = container.createDiv('nn-icon-item');
         iconItem.setAttribute('data-icon-id', fullIconId);
+        if (this.currentIcon && fullIconId === this.currentIcon) {
+            iconItem.addClass('nn-icon-item-selected');
+        }
 
         // Icon preview
         const iconPreview = iconItem.createDiv('nn-icon-item-preview');
@@ -693,6 +725,15 @@ export class IconPickerModal extends Modal {
     private async selectIcon(iconId: string) {
         // Save to recent icons
         this.saveToRecentIcons(iconId);
+
+        // Embedded mode: stage the selection without persisting or closing the host modal
+        if (this.embedded) {
+            this.currentIcon = iconId;
+            this.cleared = false;
+            this.onSelectCallback?.(iconId);
+            this.updateResults();
+            return;
+        }
 
         // Delegate to caller when a handler is provided to support multi-selection updates
         if (await this.wasHandledBySelection(iconId)) {
@@ -1035,15 +1076,32 @@ export class IconPickerModal extends Modal {
         return this.providerTabs.find(tab => tab.dataset.providerId === this.currentProvider) ?? null;
     }
 
-    onClose() {
+    /** Returns the currently staged icon id, or undefined if none selected */
+    getStagedIcon(): string | undefined {
+        return this.currentIcon;
+    }
+
+    /** Returns true if the icon has been flagged for removal */
+    isIconCleared(): boolean {
+        return this.cleared;
+    }
+
+    /** Stages removal of the icon (used by the embedding host's reset action) */
+    clearSelection(): void {
+        this.currentIcon = undefined;
+        this.cleared = true;
+        this.onSelectCallback?.(null);
+        if (this.resultsContainer) {
+            this.updateResults();
+        }
+    }
+
+    /** Releases listeners and timers. Shared by standalone onClose and the embedding host. */
+    detach(): void {
         if (this.searchDebounceTimer) {
             window.clearTimeout(this.searchDebounceTimer);
             this.searchDebounceTimer = null;
         }
-
-        const { contentEl } = this;
-        contentEl.empty();
-        this.modalEl.removeClass('nn-icon-picker-modal');
         this.removeButton = null;
         this.providerLinkContainer = null;
         this.providerLinkEl = null;
@@ -1058,6 +1116,13 @@ export class IconPickerModal extends Modal {
             });
             this.domDisposers = [];
         }
+    }
+
+    onClose() {
+        const { contentEl } = this;
+        contentEl.empty();
+        this.modalEl.removeClass('nn-icon-picker-modal');
+        this.detach();
     }
 
     // Attaches event handlers to the modal close button to ensure proper modal closure

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -122,6 +122,8 @@ Keep this list ordered: later files override earlier ones.
 /* Additional modals */
 /* modal-color-picker.css: color picker modal layout, palette grid, recent colors, and input rows. */
 @import './sections/modal-color-picker.css';
+/* modal-appearance.css: combined appearance modal (tabs hosting icon/color/background pickers). */
+@import './sections/modal-appearance.css';
 
 /* Theme + platform */
 /* theme-folder-colors.css: placeholder section for folder color rules (currently empty). */

--- a/src/styles/sections/modal-appearance.css
+++ b/src/styles/sections/modal-appearance.css
@@ -1,0 +1,193 @@
+/* Source: src/styles/sections/modal-appearance.css */
+
+/* ========================================================================
+   Appearance Modal - tabbed icon / color / background editor
+   ======================================================================== */
+
+.modal.nn-appearance-modal {
+    width: 520px;
+    max-width: calc(100vw - 40px);
+    max-height: 85vh;
+}
+
+.modal.nn-appearance-modal .modal-content {
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    overflow: hidden;
+}
+
+.modal.nn-appearance-modal .modal-close-button {
+    z-index: 10;
+    pointer-events: auto;
+}
+
+/* Header doubles as a live preview of the item */
+.nn-appearance-header {
+    display: flex;
+    justify-content: center;
+}
+
+.nn-appearance-preview {
+    display: flex;
+    justify-content: center;
+    max-width: 100%;
+}
+
+.nn-appearance-preview-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    max-width: 100%;
+    padding: 6px 16px;
+    border-radius: var(--radius-m);
+    border: 1px solid var(--background-modifier-border);
+    background: var(--nn-preview-bg, var(--background-secondary));
+    color: var(--nn-preview-fg, var(--nn-theme-foreground));
+    font-size: 15px;
+    font-weight: 600;
+}
+
+.nn-appearance-preview-icon {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+}
+
+.nn-appearance-preview-icon svg {
+    width: 18px;
+    height: 18px;
+}
+
+.nn-appearance-preview-icon.nn-appearance-preview-icon-empty {
+    display: none;
+}
+
+.nn-appearance-preview-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* Tab bar */
+.nn-appearance-tabs {
+    display: flex;
+    gap: 4px;
+    border-bottom: 1px solid var(--background-modifier-border);
+}
+
+.nn-appearance-tab {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 14px;
+    cursor: pointer;
+    color: var(--nn-theme-foreground-muted);
+    border-bottom: 2px solid transparent;
+    margin-bottom: -1px;
+    font-size: 13px;
+    font-weight: 500;
+    user-select: none;
+}
+
+.nn-appearance-tab:hover {
+    color: var(--nn-theme-foreground);
+}
+
+.nn-appearance-tab.nn-active {
+    color: var(--nn-theme-foreground);
+    border-bottom-color: var(--interactive-accent);
+}
+
+.nn-appearance-tab-icon {
+    display: inline-flex;
+    align-items: center;
+}
+
+.nn-appearance-tab-icon svg {
+    width: 15px;
+    height: 15px;
+}
+
+/* Body + panels */
+.nn-appearance-body {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    min-height: 320px;
+}
+
+.nn-appearance-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.nn-appearance-panel-hidden {
+    display: none;
+}
+
+/* Reset row (per-aspect remove control) */
+.nn-appearance-reset-row {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.nn-appearance-reset-button {
+    padding: 4px 10px;
+    font-size: 12px;
+    background: transparent;
+    color: var(--nn-theme-foreground-muted);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-s);
+    cursor: pointer;
+}
+
+.nn-appearance-reset-button:hover {
+    color: var(--nn-theme-foreground);
+    border-color: var(--background-modifier-border-hover);
+}
+
+.nn-appearance-reset-button.nn-appearance-reset-active {
+    color: var(--text-on-accent);
+    background: var(--interactive-accent);
+    border-color: var(--interactive-accent);
+}
+
+/* Host containers strip the embedded modals' own outer padding */
+.nn-appearance-picker-host {
+    display: flex;
+    flex-direction: column;
+}
+
+/* Color picker reuses its own layout; just remove the now-unneeded bottom auto-margins */
+.nn-appearance-picker-host .nn-color-picker-content {
+    overflow: visible;
+}
+
+/* Selected icon highlight (icon picker embedded staging mode) */
+.nn-icon-item.nn-icon-item-selected {
+    outline: 2px solid var(--interactive-accent);
+    outline-offset: -2px;
+    border-radius: var(--radius-s);
+}
+
+/* Footer */
+.nn-appearance-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding-top: 12px;
+    border-top: 1px solid var(--background-modifier-border);
+}
+
+/* Mobile */
+@media (max-width: 600px) {
+    .modal.nn-appearance-modal {
+        width: 100%;
+    }
+
+    .nn-appearance-body {
+        min-height: 0;
+    }
+}

--- a/src/styles/sections/modal-color-picker.css
+++ b/src/styles/sections/modal-color-picker.css
@@ -86,8 +86,6 @@
 }
 
 .nn-preview-label,
-.nn-rgb-label,
-.nn-rgb-title,
 .nn-hex-title {
     font-size: 11px;
     color: var(--nn-theme-foreground-muted);
@@ -148,88 +146,89 @@
     height: 16px;
 }
 
-/* RGB sliders section */
-.nn-rgb-section,
+/* Visual color picker section */
+.nn-color-area-section,
 .nn-color-preview-section {
     padding-bottom: 15px;
 }
 
-.nn-rgb-section {
+.nn-color-area-section {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
     margin-bottom: auto; /* Push everything below to the bottom */
 }
 
-.nn-rgb-title {
-    margin-bottom: 6px;
+/* Saturation (x) / brightness (y) 2D area */
+.nn-sv-area {
+    position: relative;
+    width: 100%;
+    height: 150px;
+    border-radius: var(--radius-m);
+    border: 1px solid var(--background-modifier-border);
+    cursor: crosshair;
+    touch-action: none;
+    background-image:
+        linear-gradient(to top, #000000, rgba(0, 0, 0, 0)),
+        linear-gradient(to right, #ffffff, rgba(255, 255, 255, 0));
+    background-color: var(--nn-sv-hue, #ff0000);
 }
 
-.nn-rgb-row {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    margin-bottom: 8px;
+.nn-sv-thumb {
+    position: absolute;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    border: 2px solid #ffffff;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.5);
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+    background: var(--nn-thumb-color, #ffffff);
 }
 
-.nn-rgb-row:last-child {
-    margin-bottom: 0;
-}
-
-.nn-rgb-label {
-    width: 16px;
-}
-
-.nn-rgb-slider {
-    flex: 1;
-    height: 4px;
-    -webkit-appearance: none;
-    appearance: none;
-    background: var(--background-modifier-border);
-    border-radius: 2px;
-    outline: none;
+/* Hue and alpha sliders */
+.nn-color-slider {
+    position: relative;
+    width: 100%;
+    height: 14px;
+    border-radius: 7px;
     cursor: pointer;
+    touch-action: none;
 }
 
-/* Slider thumb */
-.nn-rgb-slider::-webkit-slider-thumb {
-    -webkit-appearance: none;
-    appearance: none;
+.nn-hue-slider {
+    background: linear-gradient(
+        to right,
+        #ff0000 0%,
+        #ffff00 16.66%,
+        #00ff00 33.33%,
+        #00ffff 50%,
+        #0000ff 66.66%,
+        #ff00ff 83.33%,
+        #ff0000 100%
+    );
+}
+
+.nn-alpha-gradient {
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(to right, rgba(0, 0, 0, 0), var(--nn-alpha-color, #000000));
+    pointer-events: none;
+}
+
+.nn-color-slider .nn-slider-thumb {
+    position: absolute;
+    top: 50%;
     width: 16px;
     height: 16px;
     border-radius: 50%;
-    background: var(--interactive-accent);
-    cursor: pointer;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
-}
-
-.nn-rgb-slider::-moz-range-thumb {
-    width: 16px;
-    height: 16px;
-    border-radius: 50%;
-    background: var(--interactive-accent);
-    cursor: pointer;
-    border: none;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
-}
-
-/* RGB value display */
-.nn-rgb-value {
-    width: 32px;
-    text-align: right;
-    font-size: 11px;
-    color: var(--nn-theme-foreground-muted);
-    font-family: var(--font-monospace);
-}
-
-/* Color gradients for sliders */
-.nn-rgb-slider-r {
-    background: linear-gradient(to right, #000000, #ff0000);
-}
-
-.nn-rgb-slider-g {
-    background: linear-gradient(to right, #000000, #00ff00);
-}
-
-.nn-rgb-slider-b {
-    background: linear-gradient(to right, #000000, #0000ff);
+    border: 2px solid #ffffff;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.5);
+    background: transparent;
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+    z-index: 1;
 }
 
 /* Hex input section */

--- a/src/utils/contextMenu/fileMenuBuilder.ts
+++ b/src/utils/contextMenu/fileMenuBuilder.ts
@@ -665,63 +665,51 @@ function addFileStyleActionsForFileContext(params: FileStyleActionsParams): void
     const removableStyleAvailability = resolveFileStyleRemovalAvailability(targetFiles, metadataService);
     const { hasRemovableIcon, hasRemovableColor, hasRemovableBackground } = removableStyleAvailability;
 
-    if (settings.showFileIcons) {
-        menu.addItem((item: MenuItem) => {
-            setAsyncOnClick(item.setTitle(strings.contextMenu.file.changeIcon).setIcon('lucide-image'), async () => {
-                const { IconPickerModal } = await import('../../modals/IconPickerModal');
-                const modal = new IconPickerModal(app, metadataService, file.path, ItemType.FILE);
-                modal.onChooseIcon = async iconId => {
-                    if (iconId === undefined) {
-                        return { handled: true };
+    menu.addItem((item: MenuItem) => {
+        setAsyncOnClick(item.setTitle(strings.modals.appearance.menuTitle).setIcon('lucide-palette'), async () => {
+            const { AppearanceModal } = await import('../../modals/AppearanceModal');
+            const modal = new AppearanceModal(app, {
+                title: file.basename,
+                metadataService,
+                itemPath: file.path,
+                itemType: ItemType.FILE,
+                icon: settings.showFileIcons
+                    ? {
+                          initial: metadataService.getFileIcon(file.path) ?? null,
+                          apply: async iconId => {
+                              await Promise.all(
+                                  targetFiles.map(selectedFile =>
+                                      iconId === null
+                                          ? metadataService.removeFileIcon(selectedFile.path)
+                                          : metadataService.setFileIcon(selectedFile.path, iconId)
+                                  )
+                              );
+                          }
+                      }
+                    : undefined,
+                color: {
+                    initial: metadataService.getFileColor(file.path) ?? null,
+                    apply: async color => {
+                        await Promise.all(
+                            targetFiles.map(selectedFile =>
+                                color === null
+                                    ? metadataService.removeFileColor(selectedFile.path)
+                                    : metadataService.setFileColor(selectedFile.path, color)
+                            )
+                        );
                     }
-
-                    const actions = targetFiles.map(selectedFile =>
-                        iconId === null
-                            ? metadataService.removeFileIcon(selectedFile.path)
-                            : metadataService.setFileIcon(selectedFile.path, iconId)
-                    );
-                    await Promise.all(actions);
-                    return { handled: true };
-                };
-                modal.open();
-            });
-        });
-    }
-
-    menu.addItem((item: MenuItem) => {
-        setAsyncOnClick(item.setTitle(strings.contextMenu.file.changeColor).setIcon('lucide-palette'), async () => {
-            const { ColorPickerModal } = await import('../../modals/ColorPickerModal');
-            const modal = new ColorPickerModal(app, {
-                title: file.basename,
-                initialColor: metadataService.getFileColor(file.path) ?? null,
-                settingsProvider: metadataService.getSettingsProvider(),
-                onChooseColor: async color => {
-                    const actions = targetFiles.map(selectedFile =>
-                        color === null
-                            ? metadataService.removeFileColor(selectedFile.path)
-                            : metadataService.setFileColor(selectedFile.path, color)
-                    );
-                    await Promise.all(actions);
-                }
-            });
-            modal.open();
-        });
-    });
-
-    menu.addItem((item: MenuItem) => {
-        setAsyncOnClick(item.setTitle(strings.contextMenu.folder.changeBackground).setIcon('lucide-paint-bucket'), async () => {
-            const { ColorPickerModal } = await import('../../modals/ColorPickerModal');
-            const modal = new ColorPickerModal(app, {
-                title: file.basename,
-                initialColor: metadataService.getFileBackgroundColor(file.path) ?? null,
-                settingsProvider: metadataService.getSettingsProvider(),
-                onChooseColor: async color => {
-                    const actions = targetFiles.map(selectedFile =>
-                        color === null
-                            ? metadataService.removeFileBackgroundColor(selectedFile.path)
-                            : metadataService.setFileBackgroundColor(selectedFile.path, color)
-                    );
-                    await Promise.all(actions);
+                },
+                background: {
+                    initial: metadataService.getFileBackgroundColor(file.path) ?? null,
+                    apply: async color => {
+                        await Promise.all(
+                            targetFiles.map(selectedFile =>
+                                color === null
+                                    ? metadataService.removeFileBackgroundColor(selectedFile.path)
+                                    : metadataService.setFileBackgroundColor(selectedFile.path, color)
+                            )
+                        );
+                    }
                 }
             });
             modal.open();

--- a/src/utils/contextMenu/navigationSectionMenuBuilder.ts
+++ b/src/utils/contextMenu/navigationSectionMenuBuilder.ts
@@ -247,60 +247,30 @@ export function showNavigationSectionContextMenu({
             await settingsProvider.saveSettingsAndUpdate();
         };
 
-        if (virtualRootMenuConfig) {
-            menu.addItem(item => {
-                item.setTitle(strings.contextMenu.folder.changeIcon)
-                    .setIcon('lucide-image')
-                    .onClick(() => {
-                        runAsyncAction(async () => {
-                            const { IconPickerModal } = await import('../../modals/IconPickerModal');
-                            const modal = new IconPickerModal(app, metadataService, virtualFolderId, ItemType.FILE, {
-                                titleOverride,
-                                currentIconId: resolveUXIcon(settingsProvider.settings.interfaceIcons, virtualRootMenuConfig.uxIconId),
-                                showRemoveButton: true,
-                                disableMetadataUpdates: true
-                            });
-                            modal.onChooseIcon = async iconId => {
-                                await setVirtualRootIcon(virtualRootMenuConfig.uxIconId, iconId);
-                                return { handled: true };
-                            };
-                            modal.open();
-                        });
-                    });
-            });
-        }
-
         menu.addItem(item => {
-            item.setTitle(strings.contextMenu.folder.changeColor)
+            item.setTitle(strings.modals.appearance.menuTitle)
                 .setIcon('lucide-palette')
                 .onClick(() => {
                     runAsyncAction(async () => {
-                        const { ColorPickerModal } = await import('../../modals/ColorPickerModal');
-                        const modal = new ColorPickerModal(app, {
+                        const { AppearanceModal } = await import('../../modals/AppearanceModal');
+                        const modal = new AppearanceModal(app, {
                             title: titleOverride,
-                            initialColor: virtualFolderColor ?? null,
-                            settingsProvider,
-                            onChooseColor: async color => {
-                                await setVirtualFolderStyle(virtualFolderId, { color });
-                            }
-                        });
-                        modal.open();
-                    });
-                });
-        });
-
-        menu.addItem(item => {
-            item.setTitle(strings.contextMenu.folder.changeBackground)
-                .setIcon('lucide-paint-bucket')
-                .onClick(() => {
-                    runAsyncAction(async () => {
-                        const { ColorPickerModal } = await import('../../modals/ColorPickerModal');
-                        const modal = new ColorPickerModal(app, {
-                            title: titleOverride,
-                            initialColor: virtualFolderBackgroundColor ?? null,
-                            settingsProvider,
-                            onChooseColor: async color => {
-                                await setVirtualFolderStyle(virtualFolderId, { background: color });
+                            metadataService,
+                            itemPath: virtualFolderId,
+                            itemType: ItemType.FILE,
+                            icon: virtualRootMenuConfig
+                                ? {
+                                      initial: resolveUXIcon(settingsProvider.settings.interfaceIcons, virtualRootMenuConfig.uxIconId) ?? null,
+                                      apply: async iconId => setVirtualRootIcon(virtualRootMenuConfig.uxIconId, iconId)
+                                  }
+                                : undefined,
+                            color: {
+                                initial: virtualFolderColor ?? null,
+                                apply: async color => setVirtualFolderStyle(virtualFolderId, { color })
+                            },
+                            background: {
+                                initial: virtualFolderBackgroundColor ?? null,
+                                apply: async color => setVirtualFolderStyle(virtualFolderId, { background: color })
                             }
                         });
                         modal.open();

--- a/src/utils/contextMenu/propertyMenuBuilder.ts
+++ b/src/utils/contextMenu/propertyMenuBuilder.ts
@@ -190,50 +190,36 @@ export function buildPropertyMenu(params: PropertyMenuBuilderParams): void {
     });
     menu.addSeparator();
 
-    if (settings.showPropertyIcons) {
-        menu.addItem((item: MenuItem) => {
-            setAsyncOnClick(item.setTitle(strings.contextMenu.tag.changeIcon).setIcon('lucide-image'), async () => {
-                const { IconPickerModal } = await import('../../modals/IconPickerModal');
-                const modal = new IconPickerModal(app, metadataService, normalizedNodeId, ItemType.PROPERTY, { titleOverride: label });
-                modal.open();
-            });
-        });
-    }
-
     menu.addItem((item: MenuItem) => {
-        setAsyncOnClick(item.setTitle(strings.contextMenu.tag.changeColor).setIcon('lucide-palette'), async () => {
-            const { ColorPickerModal } = await import('../../modals/ColorPickerModal');
-            const modal = new ColorPickerModal(app, {
+        setAsyncOnClick(item.setTitle(strings.modals.appearance.menuTitle).setIcon('lucide-palette'), async () => {
+            const { AppearanceModal } = await import('../../modals/AppearanceModal');
+            const modal = new AppearanceModal(app, {
                 title: label,
-                initialColor: metadataService.getPropertyColor(normalizedNodeId) ?? null,
-                settingsProvider: metadataService.getSettingsProvider(),
-                onChooseColor: async color => {
-                    if (color === null) {
-                        await metadataService.removePropertyColor(normalizedNodeId);
-                        return;
-                    }
-
-                    await metadataService.setPropertyColor(normalizedNodeId, color);
-                }
-            });
-            modal.open();
-        });
-    });
-
-    menu.addItem((item: MenuItem) => {
-        setAsyncOnClick(item.setTitle(strings.contextMenu.tag.changeBackground).setIcon('lucide-paint-bucket'), async () => {
-            const { ColorPickerModal } = await import('../../modals/ColorPickerModal');
-            const modal = new ColorPickerModal(app, {
-                title: label,
-                initialColor: metadataService.getPropertyBackgroundColor(normalizedNodeId) ?? null,
-                settingsProvider: metadataService.getSettingsProvider(),
-                onChooseColor: async color => {
-                    if (color === null) {
-                        await metadataService.removePropertyBackgroundColor(normalizedNodeId);
-                        return;
-                    }
-
-                    await metadataService.setPropertyBackgroundColor(normalizedNodeId, color);
+                metadataService,
+                itemPath: normalizedNodeId,
+                itemType: ItemType.PROPERTY,
+                icon: settings.showPropertyIcons
+                    ? {
+                          initial: metadataService.getPropertyIcon(normalizedNodeId) ?? null,
+                          apply: async iconId =>
+                              iconId === null
+                                  ? metadataService.removePropertyIcon(normalizedNodeId)
+                                  : metadataService.setPropertyIcon(normalizedNodeId, iconId)
+                      }
+                    : undefined,
+                color: {
+                    initial: metadataService.getPropertyColor(normalizedNodeId) ?? null,
+                    apply: async color =>
+                        color === null
+                            ? metadataService.removePropertyColor(normalizedNodeId)
+                            : metadataService.setPropertyColor(normalizedNodeId, color)
+                },
+                background: {
+                    initial: metadataService.getPropertyBackgroundColor(normalizedNodeId) ?? null,
+                    apply: async color =>
+                        color === null
+                            ? metadataService.removePropertyBackgroundColor(normalizedNodeId)
+                            : metadataService.setPropertyBackgroundColor(normalizedNodeId, color)
                 }
             });
             modal.open();

--- a/src/utils/contextMenu/styleMenuBuilder.ts
+++ b/src/utils/contextMenu/styleMenuBuilder.ts
@@ -73,50 +73,34 @@ export function addFolderStyleChangeActions(params: AddFolderStyleChangeActionsP
     const { menu, app, metadataService, folderPath, showFolderIcons } = params;
     const folderLabel = folderPath.split('/').pop() || folderPath;
 
-    if (showFolderIcons) {
-        menu.addItem((item: MenuItem) => {
-            setAsyncOnClick(item.setTitle(strings.contextMenu.folder.changeIcon).setIcon('lucide-image'), async () => {
-                const { IconPickerModal } = await import('../../modals/IconPickerModal');
-                const modal = new IconPickerModal(app, metadataService, folderPath, ItemType.FOLDER);
-                modal.open();
-            });
-        });
-    }
-
     menu.addItem((item: MenuItem) => {
-        setAsyncOnClick(item.setTitle(strings.contextMenu.folder.changeColor).setIcon('lucide-palette'), async () => {
-            const { ColorPickerModal } = await import('../../modals/ColorPickerModal');
-            const modal = new ColorPickerModal(app, {
+        setAsyncOnClick(item.setTitle(strings.modals.appearance.menuTitle).setIcon('lucide-palette'), async () => {
+            const { AppearanceModal } = await import('../../modals/AppearanceModal');
+            const modal = new AppearanceModal(app, {
                 title: folderLabel,
-                initialColor: metadataService.getFolderColor(folderPath) ?? null,
-                settingsProvider: metadataService.getSettingsProvider(),
-                onChooseColor: async color => {
-                    if (color === null) {
-                        await metadataService.removeFolderColor(folderPath);
-                        return;
-                    }
-
-                    await metadataService.setFolderColor(folderPath, color);
-                }
-            });
-            modal.open();
-        });
-    });
-
-    menu.addItem((item: MenuItem) => {
-        setAsyncOnClick(item.setTitle(strings.contextMenu.folder.changeBackground).setIcon('lucide-paint-bucket'), async () => {
-            const { ColorPickerModal } = await import('../../modals/ColorPickerModal');
-            const modal = new ColorPickerModal(app, {
-                title: folderLabel,
-                initialColor: metadataService.getFolderBackgroundColor(folderPath) ?? null,
-                settingsProvider: metadataService.getSettingsProvider(),
-                onChooseColor: async color => {
-                    if (color === null) {
-                        await metadataService.removeFolderBackgroundColor(folderPath);
-                        return;
-                    }
-
-                    await metadataService.setFolderBackgroundColor(folderPath, color);
+                metadataService,
+                itemPath: folderPath,
+                itemType: ItemType.FOLDER,
+                icon: showFolderIcons
+                    ? {
+                          initial: metadataService.getFolderIcon(folderPath) ?? null,
+                          apply: async iconId =>
+                              iconId === null
+                                  ? metadataService.removeFolderIcon(folderPath)
+                                  : metadataService.setFolderIcon(folderPath, iconId)
+                      }
+                    : undefined,
+                color: {
+                    initial: metadataService.getFolderColor(folderPath) ?? null,
+                    apply: async color =>
+                        color === null ? metadataService.removeFolderColor(folderPath) : metadataService.setFolderColor(folderPath, color)
+                },
+                background: {
+                    initial: metadataService.getFolderBackgroundColor(folderPath) ?? null,
+                    apply: async color =>
+                        color === null
+                            ? metadataService.removeFolderBackgroundColor(folderPath)
+                            : metadataService.setFolderBackgroundColor(folderPath, color)
                 }
             });
             modal.open();

--- a/src/utils/contextMenu/tagMenuBuilder.ts
+++ b/src/utils/contextMenu/tagMenuBuilder.ts
@@ -93,53 +93,33 @@ export function buildTagMenu(params: TagMenuBuilderParams): void {
         menu.addSeparator();
     }
 
-    // Change icon
-    if (settings.showTagIcons) {
-        menu.addItem((item: MenuItem) => {
-            setAsyncOnClick(item.setTitle(strings.contextMenu.tag.changeIcon).setIcon('lucide-image'), async () => {
-                const { IconPickerModal } = await import('../../modals/IconPickerModal');
-                const modal = new IconPickerModal(app, metadataService, tagPath, ItemType.TAG);
-                modal.open();
-            });
-        });
-    }
-
-    // Change color
+    // Change appearance (icon, color, background)
     menu.addItem((item: MenuItem) => {
-        setAsyncOnClick(item.setTitle(strings.contextMenu.tag.changeColor).setIcon('lucide-palette'), async () => {
-            const { ColorPickerModal } = await import('../../modals/ColorPickerModal');
-            const modal = new ColorPickerModal(app, {
+        setAsyncOnClick(item.setTitle(strings.modals.appearance.menuTitle).setIcon('lucide-palette'), async () => {
+            const { AppearanceModal } = await import('../../modals/AppearanceModal');
+            const modal = new AppearanceModal(app, {
                 title: `#${tagPath}`,
-                initialColor: metadataService.getTagColor(tagPath) ?? null,
-                settingsProvider: metadataService.getSettingsProvider(),
-                onChooseColor: async color => {
-                    if (color === null) {
-                        await metadataService.removeTagColor(tagPath);
-                        return;
-                    }
-
-                    await metadataService.setTagColor(tagPath, color);
-                }
-            });
-            modal.open();
-        });
-    });
-
-    // Change background color
-    menu.addItem((item: MenuItem) => {
-        setAsyncOnClick(item.setTitle(strings.contextMenu.tag.changeBackground).setIcon('lucide-paint-bucket'), async () => {
-            const { ColorPickerModal } = await import('../../modals/ColorPickerModal');
-            const modal = new ColorPickerModal(app, {
-                title: `#${tagPath}`,
-                initialColor: metadataService.getTagBackgroundColor(tagPath) ?? null,
-                settingsProvider: metadataService.getSettingsProvider(),
-                onChooseColor: async color => {
-                    if (color === null) {
-                        await metadataService.removeTagBackgroundColor(tagPath);
-                        return;
-                    }
-
-                    await metadataService.setTagBackgroundColor(tagPath, color);
+                metadataService,
+                itemPath: tagPath,
+                itemType: ItemType.TAG,
+                icon: settings.showTagIcons
+                    ? {
+                          initial: metadataService.getTagIcon(tagPath) ?? null,
+                          apply: async iconId =>
+                              iconId === null ? metadataService.removeTagIcon(tagPath) : metadataService.setTagIcon(tagPath, iconId)
+                      }
+                    : undefined,
+                color: {
+                    initial: metadataService.getTagColor(tagPath) ?? null,
+                    apply: async color =>
+                        color === null ? metadataService.removeTagColor(tagPath) : metadataService.setTagColor(tagPath, color)
+                },
+                background: {
+                    initial: metadataService.getTagBackgroundColor(tagPath) ?? null,
+                    apply: async color =>
+                        color === null
+                            ? metadataService.removeTagBackgroundColor(tagPath)
+                            : metadataService.setTagBackgroundColor(tagPath, color)
                 }
             });
             modal.open();

--- a/styles.css
+++ b/styles.css
@@ -7323,8 +7323,6 @@ button.nn-youtube-button svg {
 }
 
 .nn-preview-label,
-.nn-rgb-label,
-.nn-rgb-title,
 .nn-hex-title {
     font-size: 11px;
     color: var(--nn-theme-foreground-muted);
@@ -7385,88 +7383,89 @@ button.nn-youtube-button svg {
     height: 16px;
 }
 
-/* RGB sliders section */
-.nn-rgb-section,
+/* Visual color picker section */
+.nn-color-area-section,
 .nn-color-preview-section {
     padding-bottom: 15px;
 }
 
-.nn-rgb-section {
+.nn-color-area-section {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
     margin-bottom: auto; /* Push everything below to the bottom */
 }
 
-.nn-rgb-title {
-    margin-bottom: 6px;
+/* Saturation (x) / brightness (y) 2D area */
+.nn-sv-area {
+    position: relative;
+    width: 100%;
+    height: 150px;
+    border-radius: var(--radius-m);
+    border: 1px solid var(--background-modifier-border);
+    cursor: crosshair;
+    touch-action: none;
+    background-image:
+        linear-gradient(to top, #000000, rgba(0, 0, 0, 0)),
+        linear-gradient(to right, #ffffff, rgba(255, 255, 255, 0));
+    background-color: var(--nn-sv-hue, #ff0000);
 }
 
-.nn-rgb-row {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    margin-bottom: 8px;
+.nn-sv-thumb {
+    position: absolute;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    border: 2px solid #ffffff;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.5);
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+    background: var(--nn-thumb-color, #ffffff);
 }
 
-.nn-rgb-row:last-child {
-    margin-bottom: 0;
-}
-
-.nn-rgb-label {
-    width: 16px;
-}
-
-.nn-rgb-slider {
-    flex: 1;
-    height: 4px;
-    -webkit-appearance: none;
-    appearance: none;
-    background: var(--background-modifier-border);
-    border-radius: 2px;
-    outline: none;
+/* Hue and alpha sliders */
+.nn-color-slider {
+    position: relative;
+    width: 100%;
+    height: 14px;
+    border-radius: 7px;
     cursor: pointer;
+    touch-action: none;
 }
 
-/* Slider thumb */
-.nn-rgb-slider::-webkit-slider-thumb {
-    -webkit-appearance: none;
-    appearance: none;
+.nn-hue-slider {
+    background: linear-gradient(
+        to right,
+        #ff0000 0%,
+        #ffff00 16.66%,
+        #00ff00 33.33%,
+        #00ffff 50%,
+        #0000ff 66.66%,
+        #ff00ff 83.33%,
+        #ff0000 100%
+    );
+}
+
+.nn-alpha-gradient {
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(to right, rgba(0, 0, 0, 0), var(--nn-alpha-color, #000000));
+    pointer-events: none;
+}
+
+.nn-color-slider .nn-slider-thumb {
+    position: absolute;
+    top: 50%;
     width: 16px;
     height: 16px;
     border-radius: 50%;
-    background: var(--interactive-accent);
-    cursor: pointer;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
-}
-
-.nn-rgb-slider::-moz-range-thumb {
-    width: 16px;
-    height: 16px;
-    border-radius: 50%;
-    background: var(--interactive-accent);
-    cursor: pointer;
-    border: none;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
-}
-
-/* RGB value display */
-.nn-rgb-value {
-    width: 32px;
-    text-align: right;
-    font-size: 11px;
-    color: var(--nn-theme-foreground-muted);
-    font-family: var(--font-monospace);
-}
-
-/* Color gradients for sliders */
-.nn-rgb-slider-r {
-    background: linear-gradient(to right, #000000, #ff0000);
-}
-
-.nn-rgb-slider-g {
-    background: linear-gradient(to right, #000000, #00ff00);
-}
-
-.nn-rgb-slider-b {
-    background: linear-gradient(to right, #000000, #0000ff);
+    border: 2px solid #ffffff;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.5);
+    background: transparent;
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+    z-index: 1;
 }
 
 /* Hex input section */
@@ -7761,6 +7760,199 @@ button.nn-youtube-button svg {
     .nn-color-button-container {
         margin-top: 12px;
         padding-top: 12px;
+    }
+}
+/* Source: src/styles/sections/modal-appearance.css */
+
+/* ========================================================================
+   Appearance Modal - tabbed icon / color / background editor
+   ======================================================================== */
+
+.modal.nn-appearance-modal {
+    width: 520px;
+    max-width: calc(100vw - 40px);
+    max-height: 85vh;
+}
+
+.modal.nn-appearance-modal .modal-content {
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    overflow: hidden;
+}
+
+.modal.nn-appearance-modal .modal-close-button {
+    z-index: 10;
+    pointer-events: auto;
+}
+
+/* Header doubles as a live preview of the item */
+.nn-appearance-header {
+    display: flex;
+    justify-content: center;
+}
+
+.nn-appearance-preview {
+    display: flex;
+    justify-content: center;
+    max-width: 100%;
+}
+
+.nn-appearance-preview-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    max-width: 100%;
+    padding: 6px 16px;
+    border-radius: var(--radius-m);
+    border: 1px solid var(--background-modifier-border);
+    background: var(--nn-preview-bg, var(--background-secondary));
+    color: var(--nn-preview-fg, var(--nn-theme-foreground));
+    font-size: 15px;
+    font-weight: 600;
+}
+
+.nn-appearance-preview-icon {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+}
+
+.nn-appearance-preview-icon svg {
+    width: 18px;
+    height: 18px;
+}
+
+.nn-appearance-preview-icon.nn-appearance-preview-icon-empty {
+    display: none;
+}
+
+.nn-appearance-preview-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* Tab bar */
+.nn-appearance-tabs {
+    display: flex;
+    gap: 4px;
+    border-bottom: 1px solid var(--background-modifier-border);
+}
+
+.nn-appearance-tab {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 14px;
+    cursor: pointer;
+    color: var(--nn-theme-foreground-muted);
+    border-bottom: 2px solid transparent;
+    margin-bottom: -1px;
+    font-size: 13px;
+    font-weight: 500;
+    user-select: none;
+}
+
+.nn-appearance-tab:hover {
+    color: var(--nn-theme-foreground);
+}
+
+.nn-appearance-tab.nn-active {
+    color: var(--nn-theme-foreground);
+    border-bottom-color: var(--interactive-accent);
+}
+
+.nn-appearance-tab-icon {
+    display: inline-flex;
+    align-items: center;
+}
+
+.nn-appearance-tab-icon svg {
+    width: 15px;
+    height: 15px;
+}
+
+/* Body + panels */
+.nn-appearance-body {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    min-height: 320px;
+}
+
+.nn-appearance-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.nn-appearance-panel-hidden {
+    display: none;
+}
+
+/* Reset row (per-aspect remove control) */
+.nn-appearance-reset-row {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.nn-appearance-reset-button {
+    padding: 4px 10px;
+    font-size: 12px;
+    background: transparent;
+    color: var(--nn-theme-foreground-muted);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-s);
+    cursor: pointer;
+}
+
+.nn-appearance-reset-button:hover {
+    color: var(--nn-theme-foreground);
+    border-color: var(--background-modifier-border-hover);
+}
+
+.nn-appearance-reset-button.nn-appearance-reset-active {
+    color: var(--text-on-accent);
+    background: var(--interactive-accent);
+    border-color: var(--interactive-accent);
+}
+
+/* Host containers strip the embedded modals' own outer padding */
+.nn-appearance-picker-host {
+    display: flex;
+    flex-direction: column;
+}
+
+/* Color picker reuses its own layout; just remove the now-unneeded bottom auto-margins */
+.nn-appearance-picker-host .nn-color-picker-content {
+    overflow: visible;
+}
+
+/* Selected icon highlight (icon picker embedded staging mode) */
+.nn-icon-item.nn-icon-item-selected {
+    outline: 2px solid var(--interactive-accent);
+    outline-offset: -2px;
+    border-radius: var(--radius-s);
+}
+
+/* Footer */
+.nn-appearance-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding-top: 12px;
+    border-top: 1px solid var(--background-modifier-border);
+}
+
+/* Mobile */
+@media (max-width: 600px) {
+    .modal.nn-appearance-modal {
+        width: 100%;
+    }
+
+    .nn-appearance-body {
+        min-height: 0;
     }
 }
 /* Source: src/styles/sections/theme-folder-colors.css */


### PR DESCRIPTION

Combining three separate components (Change icon, color, background) into one modal window - `AppearanceModal`. Also with a preview display mode. Adds flexibility and convenience.

**What opens when selecting "Change appearance" in the context menu:**

<details>
<summary>Imgs</summary>
<img width="536" height="473" alt="изображение" src="https://github.com/user-attachments/assets/ad213806-d094-443c-be68-d5863c4fb18b" />
<img width="862" height="926" alt="изображение" src="https://github.com/user-attachments/assets/0e63ea82-ec66-47be-9112-e7dd8faae7e1" />
<img width="890" height="935" alt="изображение" src="https://github.com/user-attachments/assets/412e8e9b-2583-4c68-8c57-ad043df3b694" />
<img width="957" height="1105" alt="изображение" src="https://github.com/user-attachments/assets/1202c09d-829f-4533-aede-6c3d4b83f1e5" />

</details>

- "Icon" tab - search and select an icon from the Lucide/Obsidian library
- "Color" tab - visual HSV picker (2D saturation/brightness area + hue slider + transparency slider)
  instead of the three RGB sliders from the original
- "Background" tab - separate color for the row background (same HSV picker)

In the dialog header - a live preview of the navigation row, instantly reflecting all changes
before saving.



### Changes

- `src/modals/AppearanceModal.ts` - new tabbed dialog with live preview
- `src/modals/ColorPickerModal.ts` - visual HSV picker instead of RGB sliders; embedded mode added
- `src/modals/IconPickerModal.ts` - embedded mode added
- `src/utils/contextMenu/{file,navigationSection,property,style,tag}MenuBuilder.ts`
    - "Change appearance" item instead of three separate ones
- `src/styles/sections/modal-appearance.css` - AppearanceModal styles
- `src/styles/sections/modal-color-picker.css`, `src/styles/index.css`, `styles.css`
- `src/i18n/locales/{en,ru}.ts` - `appearance` block + color picker labels
