### PR TITLE
Expand per-location appearance options

### DIFF
--- a/src/components/ListPaneAppearanceMenu.tsx
+++ b/src/components/ListPaneAppearanceMenu.tsx
@@ -27,7 +27,7 @@ import {
     type ListPaneToggleKey
 } from '../settings/listPaneAppearance';
 import { strings } from '../i18n';
-import { resolveTextCountVariant, type ListDisplayMode, type NotebookNavigatorSettings, type TextCountDisplay } from '../settings/types';
+import type { ListDisplayMode, NotebookNavigatorSettings, TextCountDisplay } from '../settings/types';
 import { ItemType } from '../types';
 import { runAsyncAction } from '../utils/async';
 import { tryCreateSubmenu } from '../utils/contextMenu/menuAsyncHelpers';
@@ -164,7 +164,8 @@ export function showListPaneAppearanceMenu({
         fragment.append(createSpan({ cls: 'nn-menu-title-custom', text: title }));
         item.setTitle(fragment);
     };
-    const countLabel = (value: TextCountDisplay): string => strings.settings.items.textCountDisplay.options[value];
+    const textCountLabel = (value: TextCountDisplay): string => strings.folderAppearance.textCount.options[value];
+    const rowCounts = [1, 2, 3, 4, 5] as const;
 
     /**
      * Desktop menus use Obsidian's optional submenu API. Mobile and older Obsidian versions receive
@@ -245,48 +246,50 @@ export function showListPaneAppearanceMenu({
     menu.addSeparator();
 
     const storedTitleRows = storedFields?.titleRows;
-    addChoiceSection<number | undefined>({
-        title: `${strings.folderAppearance.titleRows}: ${resolved.titleRows}`,
+    const effectiveTitleRows = storedTitleRows ?? settings.fileNameRows;
+    addChoiceSection<number>({
+        title: `${strings.folderAppearance.titleRows.label}: ${resolved.titleRows}`,
         isCustom: storedTitleRows !== undefined,
         icon: 'lucide-text',
-        options: [
-            {
-                value: undefined,
-                title: `${strings.folderAppearance.defaultLabel} (${settings.fileNameRows})`,
-                checked: storedTitleRows === undefined
-            },
-            ...[1, 2, 3].map(rows => ({
-                value: rows,
-                title: strings.folderAppearance.titleRowOption(rows),
-                checked: storedTitleRows === rows
-            }))
-        ],
-        onSelect: titleRows => updateAppearance({ titleRows })
+        options: rowCounts.slice(0, 3).map(rows => ({
+            value: rows,
+            title: withSuffix(
+                strings.folderAppearance.titleRows.option(rows),
+                rows === settings.fileNameRows ? strings.folderAppearance.defaultSuffix : null
+            ),
+            checked: effectiveTitleRows === rows
+        })),
+        onSelect: titleRows => updateAppearance({ titleRows: titleRows === settings.fileNameRows ? undefined : titleRows })
     });
 
     if (settings.showFilePreview && !isCompact) {
         const storedPreviewRows = storedFields?.previewRows;
-        addChoiceSection<number | undefined>({
-            title: `${strings.folderAppearance.previewRows}: ${resolved.previewRows}`,
+        const effectivePreviewRows = storedPreviewRows ?? settings.previewRows;
+        addChoiceSection<number>({
+            title: `${strings.folderAppearance.previewRows.label}: ${
+                effectivePreviewRows === 0 ? strings.folderAppearance.previewRows.none : effectivePreviewRows
+            }`,
             isCustom: storedPreviewRows !== undefined,
             icon: 'lucide-file-text',
             options: [
                 {
-                    value: undefined,
-                    title: `${strings.folderAppearance.defaultLabel} (${settings.previewRows})`,
-                    checked: storedPreviewRows === undefined
+                    value: 0,
+                    title: strings.folderAppearance.previewRows.none,
+                    checked: effectivePreviewRows === 0
                 },
-                ...[1, 2, 3, 4, 5].map(rows => ({
+                ...rowCounts.map(rows => ({
                     value: rows,
-                    title: strings.folderAppearance.previewRowOption(rows),
-                    checked: storedPreviewRows === rows
+                    title: withSuffix(
+                        strings.folderAppearance.previewRows.option(rows),
+                        rows === settings.previewRows ? strings.folderAppearance.defaultSuffix : null
+                    ),
+                    checked: effectivePreviewRows === rows
                 }))
             ],
-            onSelect: previewRows => updateAppearance({ previewRows })
+            onSelect: previewRows => updateAppearance({ previewRows: previewRows === settings.previewRows ? undefined : previewRows })
         });
     }
 
-    const textCountVariant = resolveTextCountVariant(settings.textCountDisplay);
     const contentToggles: ContentToggle[] = [
         {
             key: 'showTags',
@@ -309,31 +312,19 @@ export function showListPaneAppearanceMenu({
             icon: resolveUXIconForMenu(settings.interfaceIcons, 'file-unfinished-task'),
             globalDefault: settings.showFileTaskProgress,
             available: !isCompact
-        },
-        {
-            key: 'showTextCount',
-            // The label and icon name the counts the global setting shows; word count when the global type is 'none'.
-            title: countLabel(textCountVariant),
-            icon: resolveUXIconForMenu(
-                settings.interfaceIcons,
-                textCountVariant === 'characters' ? 'file-character-count' : 'file-word-count'
-            ),
-            globalDefault: settings.textCountDisplay !== 'none',
-            // Property-placed counts render as pills, so the toggle is hidden when compact mode hides pills.
-            available: !isCompact || settings.textCountPlacement !== 'property' || settings.showFilePropertiesInCompactMode
         }
     ];
     const visibleToggles = contentToggles.filter(toggle => toggle.available);
-    if (visibleToggles.length > 0) {
+    // Property-placed counts render as pills, so the choice is hidden when compact mode hides pills.
+    const textCountAvailable = !isCompact || settings.textCountPlacement !== 'property' || settings.showFilePropertiesInCompactMode;
+    if (visibleToggles.length > 0 || textCountAvailable) {
         menu.addSeparator();
     }
     visibleToggles.forEach(toggle => {
         const stored = storedFields?.[toggle.key];
         const effective = stored ?? toggle.globalDefault;
         menu.addItem(item => {
-            // The default-off suffix tells the user an unchecked toggle comes from global settings and can be enabled here.
-            const suffix = stored === undefined && !toggle.globalDefault ? strings.folderAppearance.defaultOffSuffix : null;
-            setItemTitle(item, withSuffix(toggle.title, suffix), stored !== undefined);
+            setItemTitle(item, toggle.title, stored !== undefined);
             item.setIcon(toggle.icon)
                 .setChecked(effective)
                 .onClick(() => {
@@ -345,6 +336,29 @@ export function showListPaneAppearanceMenu({
                 });
         });
     });
+    if (textCountAvailable) {
+        const storedTextCount = storedFields?.textCount;
+        const effectiveTextCount = resolved.textCountDisplay;
+        const countIcon = resolveUXIconForMenu(
+            settings.interfaceIcons,
+            effectiveTextCount === 'characters' ? 'file-character-count' : 'file-word-count'
+        );
+        const countOptions = ['none', 'words', 'characters', 'both'] as const;
+        addChoiceSection<TextCountDisplay>({
+            title: `${strings.folderAppearance.textCount.label}: ${textCountLabel(effectiveTextCount)}`,
+            isCustom: storedTextCount !== undefined,
+            icon: countIcon,
+            options: countOptions.map(textCount => ({
+                value: textCount,
+                title: withSuffix(
+                    textCountLabel(textCount),
+                    textCount === settings.textCountDisplay ? strings.folderAppearance.defaultSuffix : null
+                ),
+                checked: effectiveTextCount === textCount
+            })),
+            onSelect: textCount => updateAppearance({ textCount: textCount === settings.textCountDisplay ? undefined : textCount })
+        });
+    }
 
     if (descendantAction) {
         menu.addSeparator();

--- a/src/i18n/locales/ar.ts
+++ b/src/i18n/locales/ar.ts
@@ -421,15 +421,28 @@ export const STRINGS_AR = {
         compactPreset: 'مضغوط',
         defaultSuffix: '(افتراضي)',
         defaultLabel: 'افتراضي',
-        titleRows: 'صفوف العنوان',
-        previewRows: 'صفوف المعاينة',
+        titleRows: {
+            label: 'صفوف العنوان',
+            option: (rows: number) => `${rows} صف عنوان`
+        },
+        previewRows: {
+            label: 'صفوف المعاينة',
+            none: 'لا شيء',
+            option: (rows: number) => `${rows} صف معاينة`
+        },
         groupBy: 'تجميع حسب',
-        titleRowOption: (rows: number) => `${rows} صف عنوان`,
-        previewRowOption: (rows: number) => `${rows} صف معاينة`,
-        defaultOffSuffix: '(معطّل افتراضيًا)',
         tags: 'وسوم',
         properties: 'الخصائص',
         tasks: 'المهام',
+        textCount: {
+            label: 'عدد النص',
+            options: {
+                none: 'لا شيء',
+                words: 'الكلمات',
+                characters: 'الأحرف',
+                both: 'الكلمات والأحرف'
+            }
+        },
         resetAppearance: 'إعادة تعيين المظهر',
         openPluginSettings: 'فتح إعدادات الإضافة…'
     },

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -422,15 +422,28 @@ export const STRINGS_DE = {
         compactPreset: 'Kompakt',
         defaultSuffix: '(Standard)',
         defaultLabel: 'Standard',
-        titleRows: 'Titelzeilen',
-        previewRows: 'Vorschauzeilen',
+        titleRows: {
+            label: 'Titelzeilen',
+            option: (rows: number) => `${rows} Titelzeile${rows === 1 ? '' : 'n'}`
+        },
+        previewRows: {
+            label: 'Vorschauzeilen',
+            none: 'Keine',
+            option: (rows: number) => `${rows} Vorschauzeile${rows === 1 ? '' : 'n'}`
+        },
         groupBy: 'Gruppieren nach',
-        titleRowOption: (rows: number) => `${rows} Titelzeile${rows === 1 ? '' : 'n'}`,
-        previewRowOption: (rows: number) => `${rows} Vorschauzeile${rows === 1 ? '' : 'n'}`,
-        defaultOffSuffix: '(standardmäßig aus)',
         tags: 'Tags',
         properties: 'Eigenschaften',
         tasks: 'Aufgaben',
+        textCount: {
+            label: 'Textzählung',
+            options: {
+                none: 'Keine',
+                words: 'Wörter',
+                characters: 'Zeichen',
+                both: 'Wörter und Zeichen'
+            }
+        },
         resetAppearance: 'Darstellung zurücksetzen',
         openPluginSettings: 'Plugin-Einstellungen öffnen…'
     },

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -421,15 +421,28 @@ export const STRINGS_EN = {
         compactPreset: 'Compact',
         defaultSuffix: '(default)',
         defaultLabel: 'Default',
-        titleRows: 'Title rows',
-        previewRows: 'Preview rows',
+        titleRows: {
+            label: 'Title rows',
+            option: (rows: number) => `${rows} title row${rows === 1 ? '' : 's'}`
+        },
+        previewRows: {
+            label: 'Preview rows',
+            none: 'None',
+            option: (rows: number) => `${rows} preview row${rows === 1 ? '' : 's'}`
+        },
         groupBy: 'Group by',
-        titleRowOption: (rows: number) => `${rows} title row${rows === 1 ? '' : 's'}`,
-        previewRowOption: (rows: number) => `${rows} preview row${rows === 1 ? '' : 's'}`,
-        defaultOffSuffix: '(default off)',
         tags: 'Tags',
         properties: 'Properties',
         tasks: 'Tasks',
+        textCount: {
+            label: 'Text count',
+            options: {
+                none: 'None',
+                words: 'Word',
+                characters: 'Character',
+                both: 'Word and character'
+            }
+        },
         resetAppearance: 'Reset appearance',
         openPluginSettings: 'Open plugin settings…'
     },

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -422,15 +422,28 @@ export const STRINGS_ES = {
         compactPreset: 'Compacto',
         defaultSuffix: '(predeterminado)',
         defaultLabel: 'Predeterminado',
-        titleRows: 'Filas de título',
-        previewRows: 'Filas de vista previa',
+        titleRows: {
+            label: 'Filas de título',
+            option: (rows: number) => `${rows} fila${rows === 1 ? '' : 's'} de título`
+        },
+        previewRows: {
+            label: 'Filas de vista previa',
+            none: 'Ninguno',
+            option: (rows: number) => `${rows} fila${rows === 1 ? '' : 's'} de vista previa`
+        },
         groupBy: 'Agrupar por',
-        titleRowOption: (rows: number) => `${rows} fila${rows === 1 ? '' : 's'} de título`,
-        previewRowOption: (rows: number) => `${rows} fila${rows === 1 ? '' : 's'} de vista previa`,
-        defaultOffSuffix: '(desactivado por defecto)',
         tags: 'Etiquetas',
         properties: 'Propiedades',
         tasks: 'Tareas',
+        textCount: {
+            label: 'Recuento de texto',
+            options: {
+                none: 'Ninguno',
+                words: 'Palabras',
+                characters: 'Caracteres',
+                both: 'Palabras y caracteres'
+            }
+        },
         resetAppearance: 'Restablecer apariencia',
         openPluginSettings: 'Abrir ajustes del complemento…'
     },

--- a/src/i18n/locales/fa.ts
+++ b/src/i18n/locales/fa.ts
@@ -421,15 +421,28 @@ export const STRINGS_FA = {
         compactPreset: 'فشرده',
         defaultSuffix: '(پیش‌فرض)',
         defaultLabel: 'پیش‌فرض',
-        titleRows: 'ردیف‌های عنوان',
-        previewRows: 'ردیف‌های پیش‌نمایش',
+        titleRows: {
+            label: 'ردیف‌های عنوان',
+            option: (rows: number) => `${rows} ردیف عنوان`
+        },
+        previewRows: {
+            label: 'ردیف‌های پیش‌نمایش',
+            none: 'هیچ‌کدام',
+            option: (rows: number) => `${rows} ردیف پیش‌نمایش`
+        },
         groupBy: 'گروه‌بندی بر اساس',
-        titleRowOption: (rows: number) => `${rows} ردیف عنوان`,
-        previewRowOption: (rows: number) => `${rows} ردیف پیش‌نمایش`,
-        defaultOffSuffix: '(به‌طور پیش‌فرض خاموش)',
         tags: 'برچسب‌ها',
         properties: 'ویژگی‌ها',
         tasks: 'وظایف',
+        textCount: {
+            label: 'شمارش متن',
+            options: {
+                none: 'هیچ‌کدام',
+                words: 'کلمات',
+                characters: 'نویسه‌ها',
+                both: 'کلمات و نویسه‌ها'
+            }
+        },
         resetAppearance: 'بازنشانی ظاهر',
         openPluginSettings: 'باز کردن تنظیمات افزونه…'
     },

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -423,15 +423,28 @@ export const STRINGS_FR = {
         compactPreset: 'Compact',
         defaultSuffix: '(par défaut)',
         defaultLabel: 'Par défaut',
-        titleRows: 'Lignes de titre',
-        previewRows: "Lignes d'aperçu",
+        titleRows: {
+            label: 'Lignes de titre',
+            option: (rows: number) => `${rows} ligne${rows === 1 ? '' : 's'} de titre`
+        },
+        previewRows: {
+            label: "Lignes d'aperçu",
+            none: 'Aucun',
+            option: (rows: number) => `${rows} ligne${rows === 1 ? '' : 's'} d'aperçu`
+        },
         groupBy: 'Grouper par',
-        titleRowOption: (rows: number) => `${rows} ligne${rows === 1 ? '' : 's'} de titre`,
-        previewRowOption: (rows: number) => `${rows} ligne${rows === 1 ? '' : 's'} d'aperçu`,
-        defaultOffSuffix: '(désactivé par défaut)',
         tags: 'Étiquettes',
         properties: 'Propriétés',
         tasks: 'Tâches',
+        textCount: {
+            label: 'Comptage du texte',
+            options: {
+                none: 'Aucun',
+                words: 'Mots',
+                characters: 'Caractères',
+                both: 'Mots et caractères'
+            }
+        },
         resetAppearance: 'Réinitialiser l’apparence',
         openPluginSettings: 'Ouvrir les réglages du module…'
     },

--- a/src/i18n/locales/id.ts
+++ b/src/i18n/locales/id.ts
@@ -422,15 +422,28 @@ export const STRINGS_ID = {
         compactPreset: 'Kompak',
         defaultSuffix: '(default)',
         defaultLabel: 'Bawaan',
-        titleRows: 'Baris judul',
-        previewRows: 'Baris pratinjau',
+        titleRows: {
+            label: 'Baris judul',
+            option: (rows: number) => `${rows} baris judul`
+        },
+        previewRows: {
+            label: 'Baris pratinjau',
+            none: 'Tidak ada',
+            option: (rows: number) => `${rows} baris pratinjau`
+        },
         groupBy: 'Kelompokkan berdasarkan',
-        titleRowOption: (rows: number) => `${rows} baris judul`,
-        previewRowOption: (rows: number) => `${rows} baris pratinjau`,
-        defaultOffSuffix: '(bawaan nonaktif)',
         tags: 'Tag',
         properties: 'Properti',
         tasks: 'Tugas',
+        textCount: {
+            label: 'Hitungan teks',
+            options: {
+                none: 'Tidak ada',
+                words: 'Kata',
+                characters: 'Karakter',
+                both: 'Kata dan karakter'
+            }
+        },
         resetAppearance: 'Atur ulang tampilan',
         openPluginSettings: 'Buka pengaturan plugin…'
     },

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -421,15 +421,28 @@ export const STRINGS_IT = {
         compactPreset: 'Compatto',
         defaultSuffix: '(predefinito)',
         defaultLabel: 'Predefinito',
-        titleRows: 'Righe titolo',
-        previewRows: 'Righe anteprima',
+        titleRows: {
+            label: 'Righe titolo',
+            option: (rows: number) => `${rows} ${rows === 1 ? 'riga' : 'righe'} titolo`
+        },
+        previewRows: {
+            label: 'Righe anteprima',
+            none: 'Nessuno',
+            option: (rows: number) => `${rows} ${rows === 1 ? 'riga' : 'righe'} anteprima`
+        },
         groupBy: 'Raggruppa per',
-        titleRowOption: (rows: number) => `${rows} ${rows === 1 ? 'riga' : 'righe'} titolo`,
-        previewRowOption: (rows: number) => `${rows} ${rows === 1 ? 'riga' : 'righe'} anteprima`,
-        defaultOffSuffix: '(predefinito: disattivato)',
         tags: 'Tag',
         properties: 'Proprietà',
         tasks: 'Attività',
+        textCount: {
+            label: 'Conteggio testo',
+            options: {
+                none: 'Nessuno',
+                words: 'Parole',
+                characters: 'Caratteri',
+                both: 'Parole e caratteri'
+            }
+        },
         resetAppearance: 'Reimposta aspetto',
         openPluginSettings: 'Apri impostazioni del plugin…'
     },

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -421,15 +421,28 @@ export const STRINGS_JA = {
         compactPreset: 'コンパクト',
         defaultSuffix: '(デフォルト)',
         defaultLabel: 'デフォルト',
-        titleRows: 'タイトル行数',
-        previewRows: 'プレビュー行数',
+        titleRows: {
+            label: 'タイトル行数',
+            option: (rows: number) => `タイトル${rows}行`
+        },
+        previewRows: {
+            label: 'プレビュー行数',
+            none: 'なし',
+            option: (rows: number) => `プレビュー${rows}行`
+        },
         groupBy: 'グループ分け',
-        titleRowOption: (rows: number) => `タイトル${rows}行`,
-        previewRowOption: (rows: number) => `プレビュー${rows}行`,
-        defaultOffSuffix: '（デフォルトはオフ）',
         tags: 'タグ',
         properties: 'プロパティ',
         tasks: 'タスク',
+        textCount: {
+            label: 'テキストカウント',
+            options: {
+                none: 'なし',
+                words: '単語',
+                characters: '文字',
+                both: '単語と文字'
+            }
+        },
         resetAppearance: '外観をリセット',
         openPluginSettings: 'プラグイン設定を開く…'
     },

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -420,15 +420,28 @@ export const STRINGS_KO = {
         compactPreset: '컴팩트',
         defaultSuffix: '(기본값)',
         defaultLabel: '기본',
-        titleRows: '제목 행',
-        previewRows: '미리보기 행',
+        titleRows: {
+            label: '제목 행',
+            option: (rows: number) => `${rows}개 제목 행`
+        },
+        previewRows: {
+            label: '미리보기 행',
+            none: '없음',
+            option: (rows: number) => `${rows}개 미리보기 행`
+        },
         groupBy: '그룹화 기준',
-        titleRowOption: (rows: number) => `${rows}개 제목 행`,
-        previewRowOption: (rows: number) => `${rows}개 미리보기 행`,
-        defaultOffSuffix: '(기본값 꺼짐)',
         tags: '태그',
         properties: '속성',
         tasks: '작업',
+        textCount: {
+            label: '텍스트 수',
+            options: {
+                none: '없음',
+                words: '단어',
+                characters: '문자',
+                both: '단어 및 문자'
+            }
+        },
         resetAppearance: '모양 재설정',
         openPluginSettings: '플러그인 설정 열기…'
     },

--- a/src/i18n/locales/nl.ts
+++ b/src/i18n/locales/nl.ts
@@ -424,15 +424,28 @@ export const STRINGS_NL = {
         compactPreset: 'Compact',
         defaultSuffix: '(standaard)',
         defaultLabel: 'Standaard',
-        titleRows: 'Titelrijen',
-        previewRows: 'Voorbeeldrijen',
+        titleRows: {
+            label: 'Titelrijen',
+            option: (rows: number) => `${rows} titelrij${rows === 1 ? '' : 'en'}`
+        },
+        previewRows: {
+            label: 'Voorbeeldrijen',
+            none: 'Geen',
+            option: (rows: number) => `${rows} voorbeeldrij${rows === 1 ? '' : 'en'}`
+        },
         groupBy: 'Groeperen op',
-        titleRowOption: (rows: number) => `${rows} titelrij${rows === 1 ? '' : 'en'}`,
-        previewRowOption: (rows: number) => `${rows} voorbeeldrij${rows === 1 ? '' : 'en'}`,
-        defaultOffSuffix: '(standaard uit)',
         tags: 'Tags',
         properties: 'Eigenschappen',
         tasks: 'Taken',
+        textCount: {
+            label: 'Teksttelling',
+            options: {
+                none: 'Geen',
+                words: 'Woorden',
+                characters: 'Tekens',
+                both: 'Woorden en tekens'
+            }
+        },
         resetAppearance: 'Weergave herstellen',
         openPluginSettings: 'Plugin-instellingen openen…'
     },

--- a/src/i18n/locales/pl.ts
+++ b/src/i18n/locales/pl.ts
@@ -422,17 +422,30 @@ export const STRINGS_PL = {
         compactPreset: 'Kompaktowy',
         defaultSuffix: '(domyślne)',
         defaultLabel: 'Domyślne',
-        titleRows: 'Wiersze tytułu',
-        previewRows: 'Wiersze podglądu',
+        titleRows: {
+            label: 'Wiersze tytułu',
+            option: (rows: number) =>
+                `${rows} ${rows === 1 ? 'wiersz' : rows === 2 || rows === 3 || rows === 4 ? 'wiersze' : 'wierszy'} tytułu`
+        },
+        previewRows: {
+            label: 'Wiersze podglądu',
+            none: 'Brak',
+            option: (rows: number) =>
+                `${rows} ${rows === 1 ? 'wiersz' : rows === 2 || rows === 3 || rows === 4 ? 'wiersze' : 'wierszy'} podglądu`
+        },
         groupBy: 'Grupuj według',
-        titleRowOption: (rows: number) =>
-            `${rows} ${rows === 1 ? 'wiersz' : rows === 2 || rows === 3 || rows === 4 ? 'wiersze' : 'wierszy'} tytułu`,
-        previewRowOption: (rows: number) =>
-            `${rows} ${rows === 1 ? 'wiersz' : rows === 2 || rows === 3 || rows === 4 ? 'wiersze' : 'wierszy'} podglądu`,
-        defaultOffSuffix: '(domyślnie wyłączone)',
         tags: 'Tagi',
         properties: 'Właściwości',
         tasks: 'Zadania',
+        textCount: {
+            label: 'Licznik tekstu',
+            options: {
+                none: 'Brak',
+                words: 'Słowa',
+                characters: 'Znaki',
+                both: 'Słowa i znaki'
+            }
+        },
         resetAppearance: 'Zresetuj wygląd',
         openPluginSettings: 'Otwórz ustawienia wtyczki…'
     },

--- a/src/i18n/locales/pt.ts
+++ b/src/i18n/locales/pt.ts
@@ -422,15 +422,28 @@ export const STRINGS_PT = {
         compactPreset: 'Compacto',
         defaultSuffix: '(predefinido)',
         defaultLabel: 'Predefinido',
-        titleRows: 'Linhas de título',
-        previewRows: 'Linhas de pré-visualização',
+        titleRows: {
+            label: 'Linhas de título',
+            option: (rows: number) => `${rows} linha${rows === 1 ? '' : 's'} de título`
+        },
+        previewRows: {
+            label: 'Linhas de pré-visualização',
+            none: 'Nenhuma',
+            option: (rows: number) => `${rows} linha${rows === 1 ? '' : 's'} de pré-visualização`
+        },
         groupBy: 'Agrupar por',
-        titleRowOption: (rows: number) => `${rows} linha${rows === 1 ? '' : 's'} de título`,
-        previewRowOption: (rows: number) => `${rows} linha${rows === 1 ? '' : 's'} de pré-visualização`,
-        defaultOffSuffix: '(desativado por predefinição)',
         tags: 'Etiquetas',
         properties: 'Propriedades',
         tasks: 'Tarefas',
+        textCount: {
+            label: 'Contagem de texto',
+            options: {
+                none: 'Nenhuma',
+                words: 'Palavras',
+                characters: 'Caracteres',
+                both: 'Palavras e caracteres'
+            }
+        },
         resetAppearance: 'Repor aparência',
         openPluginSettings: 'Abrir definições do plugin…'
     },

--- a/src/i18n/locales/pt_br.ts
+++ b/src/i18n/locales/pt_br.ts
@@ -423,15 +423,28 @@ export const STRINGS_PT_BR = {
         compactPreset: 'Compacto',
         defaultSuffix: '(padrão)',
         defaultLabel: 'Padrão',
-        titleRows: 'Linhas do título',
-        previewRows: 'Linhas de visualização',
+        titleRows: {
+            label: 'Linhas do título',
+            option: (rows: number) => `${rows} linha${rows === 1 ? '' : 's'} de título`
+        },
+        previewRows: {
+            label: 'Linhas de visualização',
+            none: 'Nenhuma',
+            option: (rows: number) => `${rows} linha${rows === 1 ? '' : 's'} de visualização`
+        },
         groupBy: 'Agrupar por',
-        titleRowOption: (rows: number) => `${rows} linha${rows === 1 ? '' : 's'} de título`,
-        previewRowOption: (rows: number) => `${rows} linha${rows === 1 ? '' : 's'} de visualização`,
-        defaultOffSuffix: '(desativado por padrão)',
         tags: 'Tags',
         properties: 'Propriedades',
         tasks: 'Tarefas',
+        textCount: {
+            label: 'Contagem de texto',
+            options: {
+                none: 'Nenhuma',
+                words: 'Palavras',
+                characters: 'Caracteres',
+                both: 'Palavras e caracteres'
+            }
+        },
         resetAppearance: 'Redefinir aparência',
         openPluginSettings: 'Abrir configurações do plugin…'
     },

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -422,15 +422,28 @@ export const STRINGS_RU = {
         compactPreset: 'Компактный',
         defaultSuffix: '(по умолчанию)',
         defaultLabel: 'По умолчанию',
-        titleRows: 'Строки заголовка',
-        previewRows: 'Строки превью',
+        titleRows: {
+            label: 'Строки заголовка',
+            option: (rows: number) => `${rows} ${rows === 1 ? 'строка' : rows < 5 ? 'строки' : 'строк'} заголовка`
+        },
+        previewRows: {
+            label: 'Строки превью',
+            none: 'Нет',
+            option: (rows: number) => `${rows} ${rows === 1 ? 'строка' : rows < 5 ? 'строки' : 'строк'} превью`
+        },
         groupBy: 'Группировать по',
-        titleRowOption: (rows: number) => `${rows} ${rows === 1 ? 'строка' : rows < 5 ? 'строки' : 'строк'} заголовка`,
-        previewRowOption: (rows: number) => `${rows} ${rows === 1 ? 'строка' : rows < 5 ? 'строки' : 'строк'} превью`,
-        defaultOffSuffix: '(по умолчанию выключено)',
         tags: 'Теги',
         properties: 'Свойства',
         tasks: 'Задачи',
+        textCount: {
+            label: 'Подсчёт текста',
+            options: {
+                none: 'Нет',
+                words: 'Слова',
+                characters: 'Символы',
+                both: 'Слова и символы'
+            }
+        },
         resetAppearance: 'Сбросить оформление',
         openPluginSettings: 'Открыть настройки плагина…'
     },

--- a/src/i18n/locales/th.ts
+++ b/src/i18n/locales/th.ts
@@ -421,15 +421,28 @@ export const STRINGS_TH = {
         compactPreset: 'กะทัดรัด',
         defaultSuffix: '(ค่าเริ่มต้น)',
         defaultLabel: 'ค่าเริ่มต้น',
-        titleRows: 'แถวชื่อเรื่อง',
-        previewRows: 'แถวตัวอย่าง',
+        titleRows: {
+            label: 'แถวชื่อเรื่อง',
+            option: (rows: number) => `${rows} แถวชื่อเรื่อง`
+        },
+        previewRows: {
+            label: 'แถวตัวอย่าง',
+            none: 'ไม่มี',
+            option: (rows: number) => `${rows} แถวตัวอย่าง`
+        },
         groupBy: 'จัดกลุ่มตาม',
-        titleRowOption: (rows: number) => `${rows} แถวชื่อเรื่อง`,
-        previewRowOption: (rows: number) => `${rows} แถวตัวอย่าง`,
-        defaultOffSuffix: '(ค่าเริ่มต้นปิด)',
         tags: 'แท็ก',
         properties: 'คุณสมบัติ',
         tasks: 'งาน',
+        textCount: {
+            label: 'การนับข้อความ',
+            options: {
+                none: 'ไม่มี',
+                words: 'คำ',
+                characters: 'อักขระ',
+                both: 'คำและอักขระ'
+            }
+        },
         resetAppearance: 'รีเซ็ตรูปลักษณ์',
         openPluginSettings: 'เปิดการตั้งค่าปลั๊กอิน…'
     },

--- a/src/i18n/locales/tr.ts
+++ b/src/i18n/locales/tr.ts
@@ -422,15 +422,28 @@ export const STRINGS_TR = {
         compactPreset: 'Kompakt',
         defaultSuffix: '(varsayılan)',
         defaultLabel: 'Varsayılan',
-        titleRows: 'Başlık satırları',
-        previewRows: 'Önizleme satırları',
+        titleRows: {
+            label: 'Başlık satırları',
+            option: (rows: number) => `${rows} başlık satırı`
+        },
+        previewRows: {
+            label: 'Önizleme satırları',
+            none: 'Yok',
+            option: (rows: number) => `${rows} önizleme satırı`
+        },
         groupBy: 'Grupla',
-        titleRowOption: (rows: number) => `${rows} başlık satırı`,
-        previewRowOption: (rows: number) => `${rows} önizleme satırı`,
-        defaultOffSuffix: '(varsayılan olarak kapalı)',
         tags: 'Etiketler',
         properties: 'Özellikler',
         tasks: 'Görevler',
+        textCount: {
+            label: 'Metin sayımı',
+            options: {
+                none: 'Yok',
+                words: 'Kelime',
+                characters: 'Karakter',
+                both: 'Kelime ve karakter'
+            }
+        },
         resetAppearance: 'Görünümü sıfırla',
         openPluginSettings: 'Eklenti ayarlarını aç…'
     },

--- a/src/i18n/locales/uk.ts
+++ b/src/i18n/locales/uk.ts
@@ -423,15 +423,28 @@ export const STRINGS_UK = {
         compactPreset: 'Компактний',
         defaultSuffix: '(за замовчуванням)',
         defaultLabel: 'За замовчуванням',
-        titleRows: 'Рядки заголовка',
-        previewRows: 'Рядки попереднього перегляду',
+        titleRows: {
+            label: 'Рядки заголовка',
+            option: (rows: number) => `${rows} ${rows === 1 ? 'рядок' : rows < 5 ? 'рядки' : 'рядків'} заголовка`
+        },
+        previewRows: {
+            label: 'Рядки попереднього перегляду',
+            none: 'Немає',
+            option: (rows: number) => `${rows} ${rows === 1 ? 'рядок' : rows < 5 ? 'рядки' : 'рядків'} попереднього перегляду`
+        },
         groupBy: 'Групувати за',
-        titleRowOption: (rows: number) => `${rows} ${rows === 1 ? 'рядок' : rows < 5 ? 'рядки' : 'рядків'} заголовка`,
-        previewRowOption: (rows: number) => `${rows} ${rows === 1 ? 'рядок' : rows < 5 ? 'рядки' : 'рядків'} попереднього перегляду`,
-        defaultOffSuffix: '(типово вимкнено)',
         tags: 'Теги',
         properties: 'Властивості',
         tasks: 'Завдання',
+        textCount: {
+            label: 'Підрахунок тексту',
+            options: {
+                none: 'Немає',
+                words: 'Слова',
+                characters: 'Символи',
+                both: 'Слова і символи'
+            }
+        },
         resetAppearance: 'Скинути оформлення',
         openPluginSettings: 'Відкрити налаштування плагіна…'
     },

--- a/src/i18n/locales/vi.ts
+++ b/src/i18n/locales/vi.ts
@@ -421,15 +421,28 @@ export const STRINGS_VI = {
         compactPreset: 'Gọn',
         defaultSuffix: '(mặc định)',
         defaultLabel: 'Mặc định',
-        titleRows: 'Dòng tiêu đề',
-        previewRows: 'Dòng xem trước',
+        titleRows: {
+            label: 'Dòng tiêu đề',
+            option: (rows: number) => `${rows} dòng tiêu đề`
+        },
+        previewRows: {
+            label: 'Dòng xem trước',
+            none: 'Không',
+            option: (rows: number) => `${rows} dòng xem trước`
+        },
         groupBy: 'Nhóm theo',
-        titleRowOption: (rows: number) => `${rows} dòng tiêu đề`,
-        previewRowOption: (rows: number) => `${rows} dòng xem trước`,
-        defaultOffSuffix: '(mặc định tắt)',
         tags: 'Thẻ',
         properties: 'Thuộc tính',
         tasks: 'Nhiệm vụ',
+        textCount: {
+            label: 'Đếm văn bản',
+            options: {
+                none: 'Không',
+                words: 'Từ',
+                characters: 'Ký tự',
+                both: 'Từ và ký tự'
+            }
+        },
         resetAppearance: 'Đặt lại giao diện',
         openPluginSettings: 'Mở cài đặt plugin…'
     },

--- a/src/i18n/locales/zh_cn.ts
+++ b/src/i18n/locales/zh_cn.ts
@@ -420,15 +420,28 @@ export const STRINGS_ZH_CN = {
         compactPreset: '紧凑',
         defaultSuffix: '(默认)',
         defaultLabel: '默认',
-        titleRows: '标题行数',
-        previewRows: '预览行数',
+        titleRows: {
+            label: '标题行数',
+            option: (rows: number) => `标题${rows}行`
+        },
+        previewRows: {
+            label: '预览行数',
+            none: '无',
+            option: (rows: number) => `预览${rows}行`
+        },
         groupBy: '分组依据',
-        titleRowOption: (rows: number) => `标题${rows}行`,
-        previewRowOption: (rows: number) => `预览${rows}行`,
-        defaultOffSuffix: '（默认关闭）',
         tags: '标签',
         properties: '属性',
         tasks: '任务',
+        textCount: {
+            label: '文本计数',
+            options: {
+                none: '无',
+                words: '字',
+                characters: '字符',
+                both: '字和字符'
+            }
+        },
         resetAppearance: '重置外观',
         openPluginSettings: '打开插件设置…'
     },

--- a/src/i18n/locales/zh_tw.ts
+++ b/src/i18n/locales/zh_tw.ts
@@ -421,15 +421,28 @@ export const STRINGS_ZH_TW = {
         compactPreset: '精簡',
         defaultSuffix: '(預設)',
         defaultLabel: '預設',
-        titleRows: '標題行數',
-        previewRows: '預覽行數',
+        titleRows: {
+            label: '標題行數',
+            option: (rows: number) => `標題${rows}行`
+        },
+        previewRows: {
+            label: '預覽行數',
+            none: '無',
+            option: (rows: number) => `預覽${rows}行`
+        },
         groupBy: '分組依據',
-        titleRowOption: (rows: number) => `標題${rows}行`,
-        previewRowOption: (rows: number) => `預覽${rows}行`,
-        defaultOffSuffix: '（預設關閉）',
         tags: '標籤',
         properties: '屬性',
         tasks: '任務',
+        textCount: {
+            label: '文字計數',
+            options: {
+                none: '無',
+                words: '字',
+                characters: '字元',
+                both: '字與字元'
+            }
+        },
         resetAppearance: '重設外觀',
         openPluginSettings: '開啟外掛程式設定…'
     },

--- a/src/releaseNotes.ts
+++ b/src/releaseNotes.ts
@@ -112,7 +112,7 @@ const RELEASE_NOTES: ReleaseNote[] = [
         showOnUpdate: true,
         bannerUrl: true,
         new: [
-            "You can now toggle the display of tags, properties, tasks, and word counts for each location! Maybe you want word counts only for a specific folder, or you don't want to show tasks in another folder. This is now possible! Just click the new ==Appearance== menu in the list pane (see screenshot above).",
+            "You can now change the display of tags, properties, tasks, and word counts for each location! Maybe you want word counts only for a specific folder, or you don't want to show tasks in another folder. This is now possible! Just click the new ==Appearance== menu in the list pane (see screenshot above).",
             "When I added the new task display in 3.3.1 I removed the unfinished task icon. Unfortunately this meant no way of showing unfinished tasks in compact mode. So I put it back, and made it better. You can now choose if you want the unfinished task icon to appear in only compact or in both display modes. You'll find it at File display > Icon > ==Unfinished task icon==. Default set to compact mode.",
             'New setting: Calendar > ==Show days from other months==. You can now leave the days before and after the current month empty, so only the days of the month are shown. Only applies when calendar is showing a full month. Enabled by default.'
         ],

--- a/src/services/settings/PluginSettingsController.ts
+++ b/src/services/settings/PluginSettingsController.ts
@@ -637,6 +637,7 @@ export class PluginSettingsController {
         });
 
         this.sanitizeSettingsRecords();
+        this.pruneInheritedAppearanceValues();
         const prunedUnavailablePropertySortOverrides = pruneUnavailablePropertySortOverrides(this.currentSettings);
         const prunedUnavailablePropertyGroupingOverrides = pruneUnavailablePropertyGroupingOverrides(this.currentSettings);
         // Load and external sync reconcile the global defaults silently; only direct settings-tab
@@ -974,6 +975,7 @@ export class PluginSettingsController {
     }
 
     public async saveSettings(): Promise<void> {
+        this.pruneInheritedAppearanceValues();
         ensureVaultProfiles(this.currentSettings);
         this.refreshMatcherCachesIfNeeded();
         localStorage.set(this.options.keys.homepageKey, this.currentSettings.homepage);
@@ -1410,6 +1412,32 @@ export class PluginSettingsController {
         this.currentSettings.syncModes = sanitizeSettingsSyncMap(this.currentSettings.syncModes);
         this.currentSettings.calendarMonthHighlights = sanitizeStringMap(this.currentSettings.calendarMonthHighlights);
         this.currentSettings.pinnedNotes = clonePinnedNotesRecord(this.currentSettings.pinnedNotes);
+    }
+
+    private pruneInheritedAppearanceValues(): void {
+        // Choices equal to their global settings are inheritance. Remove matching stored values so
+        // default-marked entries do not remain overrides after a global setting changes.
+        const appearanceMaps = [
+            this.currentSettings.folderAppearances,
+            this.currentSettings.tagAppearances,
+            this.currentSettings.propertyAppearances
+        ];
+        appearanceMaps.forEach(appearances => {
+            Object.entries(appearances).forEach(([key, appearance]) => {
+                if (appearance.titleRows === this.currentSettings.fileNameRows) {
+                    delete appearance.titleRows;
+                }
+                if (appearance.previewRows === this.currentSettings.previewRows) {
+                    delete appearance.previewRows;
+                }
+                if (appearance.textCount === this.currentSettings.textCountDisplay) {
+                    delete appearance.textCount;
+                }
+                if (Object.keys(appearance).length === 0) {
+                    delete appearances[key];
+                }
+            });
+        });
     }
 
     private normalizeTaskSettings(): void {

--- a/src/settings/listPaneAppearance.ts
+++ b/src/settings/listPaneAppearance.ts
@@ -19,7 +19,7 @@
 import { ItemType } from '../types';
 import { resolveListGroupingOverride } from '../utils/listGrouping';
 import {
-    resolveTextCountVariant,
+    isTextCountDisplay,
     type ListDisplayMode,
     type ListNoteGroupingOption,
     type ListPaneAppearance,
@@ -48,7 +48,7 @@ export interface ListPaneAppearanceSettings {
  * Both `true` and `false` are persisted so a selection can enable content that
  * the global setting turns off, and hide content that the global setting shows.
  */
-export const LIST_PANE_TOGGLE_KEYS = ['showTags', 'showProperties', 'showTaskProgress', 'showTextCount'] as const;
+export const LIST_PANE_TOGGLE_KEYS = ['showTags', 'showProperties', 'showTaskProgress'] as const;
 
 export type ListPaneToggleKey = (typeof LIST_PANE_TOGGLE_KEYS)[number];
 
@@ -58,7 +58,8 @@ const LIST_PANE_APPEARANCE_FIELD_KEYS = [
     'mode',
     'titleRows',
     'previewRows',
-    ...LIST_PANE_TOGGLE_KEYS
+    ...LIST_PANE_TOGGLE_KEYS,
+    'textCount'
 ] as const satisfies readonly (keyof ListPaneAppearanceFields)[];
 
 function isValidTitleRows(value: unknown): value is number {
@@ -66,7 +67,7 @@ function isValidTitleRows(value: unknown): value is number {
 }
 
 function isValidPreviewRows(value: unknown): value is number {
-    return typeof value === 'number' && Number.isInteger(value) && value >= 1 && value <= 5;
+    return typeof value === 'number' && Number.isInteger(value) && value >= 0 && value <= 5;
 }
 
 /**
@@ -93,6 +94,9 @@ export function getStoredListPaneAppearanceFields(appearance: ListPaneAppearance
             normalized[key] = appearance[key];
         }
     });
+    if (isTextCountDisplay(appearance.textCount)) {
+        normalized.textCount = appearance.textCount;
+    }
 
     return Object.keys(normalized).length > 0 ? normalized : null;
 }
@@ -210,11 +214,10 @@ export function resolveListPaneAppearance({
     const showProperties =
         (appearance?.showProperties ?? settings.showFileProperties) && (!isCompact || settings.showFilePropertiesInCompactMode);
     const showTaskProgress = (appearance?.showTaskProgress ?? settings.showFileTaskProgress) && !isCompact;
+    const previewRowsOverride = isValidPreviewRows(appearance?.previewRows) ? appearance.previewRows : undefined;
     // Property-placed counts render as pills, so they are unavailable when compact mode hides pills.
     const textCountUnavailable = isCompact && settings.textCountPlacement === 'property' && !settings.showFilePropertiesInCompactMode;
-    // A selection toggles counts on or off; the global setting decides which counts are shown.
-    const showTextCount = (appearance?.showTextCount ?? settings.textCountDisplay !== 'none') && !textCountUnavailable;
-    const textCountDisplay = showTextCount ? resolveTextCountVariant(settings.textCountDisplay) : 'none';
+    const textCountDisplay = textCountUnavailable ? 'none' : (appearance?.textCount ?? settings.textCountDisplay);
     const grouping = resolveListGroupingOverride({
         noteGrouping: settings.noteGrouping,
         selectionType,
@@ -224,9 +227,10 @@ export function resolveListPaneAppearance({
     return {
         mode,
         titleRows: isValidTitleRows(appearance?.titleRows) ? appearance.titleRows : settings.fileNameRows,
-        previewRows: isValidPreviewRows(appearance?.previewRows) ? appearance.previewRows : settings.previewRows,
+        // Zero hides preview text, but the configured row count still sizes feature-image and pill layouts.
+        previewRows: previewRowsOverride && previewRowsOverride > 0 ? previewRowsOverride : settings.previewRows,
         showDate: !isCompact && settings.showFileDate,
-        showPreview: !isCompact && settings.showFilePreview,
+        showPreview: !isCompact && settings.showFilePreview && previewRowsOverride !== 0,
         showImage: !isCompact && settings.showFeatureImage,
         showTags,
         showProperties,

--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -447,12 +447,14 @@ export type ListNoteGroupingOption =
 export interface ListPaneAppearance {
     mode?: ListDisplayMode;
     titleRows?: number;
+    /** Zero hides preview text for this selection; undefined inherits the global row count. */
     previewRows?: number;
     groupBy?: ListNoteGroupingOption;
     showTags?: boolean;
     showProperties?: boolean;
     showTaskProgress?: boolean;
-    showTextCount?: boolean;
+    /** Undefined inherits the global count type; `none` explicitly hides counts for this selection. */
+    textCount?: TextCountDisplay;
 }
 
 const PROPERTY_GROUPING_PREFIX = 'property:';
@@ -569,14 +571,6 @@ export function showsWordCount(display: TextCountDisplay): boolean {
 
 export function showsCharacterCount(display: TextCountDisplay): boolean {
     return display === 'characters' || display === 'both';
-}
-
-/**
- * The count type shown when a folder, tag, or property selection enables text counts.
- * The global setting decides the type; word count is the fallback when the global type is 'none'.
- */
-export function resolveTextCountVariant(display: TextCountDisplay): Exclude<TextCountDisplay, 'none'> {
-    return display === 'none' ? 'words' : display;
 }
 
 /** Buttons available in the navigation toolbar */

--- a/src/utils/markdownPipelineContentTypes.ts
+++ b/src/utils/markdownPipelineContentTypes.ts
@@ -17,16 +17,15 @@
  */
 
 import type { FileContentType } from '../interfaces/IContentProvider';
-import {
-    resolveTextCountVariant,
-    showsCharacterCount,
-    showsWordCount,
-    type NotebookNavigatorSettings,
-    type TextCountDisplay
-} from '../settings/types';
+import { showsCharacterCount, showsWordCount, type NotebookNavigatorSettings } from '../settings/types';
 import { hasWordCountTargetPropertyConsumer } from './propertyUtils';
 
-const appearanceTextCountConsumerCache = new WeakMap<object, boolean>();
+interface AppearanceTextCountConsumers {
+    words: boolean;
+    characters: boolean;
+}
+
+const appearanceTextCountConsumerCache = new WeakMap<object, AppearanceTextCountConsumers>();
 
 export function hasMarkdownPreviewConsumer(settings: NotebookNavigatorSettings): boolean {
     return settings.showFilePreview;
@@ -37,42 +36,41 @@ export function hasMarkdownFeatureImageConsumer(settings: NotebookNavigatorSetti
 }
 
 /**
- * Checks folder, tag, and property appearance overrides for an enabled text count toggle.
- * A selection can enable counts while the global count type is 'none', so count extraction
- * must run whenever any selection displays them. The global setting decides the count type.
+ * Checks folder, tag, and property appearance overrides for text count consumers.
+ * A selection can request either count while the global count type is 'none', so extraction
+ * must include every count type used by an appearance.
  */
-function hasEnabledAppearanceTextCount(settings: NotebookNavigatorSettings): boolean {
+function hasAppearanceTextCountConsumer(settings: NotebookNavigatorSettings, type: keyof AppearanceTextCountConsumers): boolean {
     // Settings snapshots keep unchanged appearance maps immutable and referentially stable, so each
-    // map is scanned only when its contents change and the result is shared across settings updates.
+    // map is scanned only when its contents change and both consumer checks share the result.
     const records = [settings.folderAppearances, settings.tagAppearances, settings.propertyAppearances];
     return records.some(record => {
-        const cached = appearanceTextCountConsumerCache.get(record);
-        if (cached !== undefined) {
-            return cached;
+        let consumers = appearanceTextCountConsumerCache.get(record);
+        if (!consumers) {
+            const detectedConsumers: AppearanceTextCountConsumers = { words: false, characters: false };
+            Object.values(record).forEach(appearance => {
+                if (appearance.textCount) {
+                    detectedConsumers.words ||= showsWordCount(appearance.textCount);
+                    detectedConsumers.characters ||= showsCharacterCount(appearance.textCount);
+                }
+            });
+            consumers = detectedConsumers;
+            appearanceTextCountConsumerCache.set(record, consumers);
         }
-        const enabled = Object.values(record).some(appearance => appearance.showTextCount === true);
-        appearanceTextCountConsumerCache.set(record, enabled);
-        return enabled;
+        return consumers[type];
     });
-}
-
-function hasAppearanceTextCountConsumer(settings: NotebookNavigatorSettings, shows: (value: TextCountDisplay) => boolean): boolean {
-    if (!shows(resolveTextCountVariant(settings.textCountDisplay))) {
-        return false;
-    }
-    return hasEnabledAppearanceTextCount(settings);
 }
 
 export function hasMarkdownWordCountConsumer(settings: NotebookNavigatorSettings): boolean {
     return (
         hasWordCountTargetPropertyConsumer(settings) ||
         (settings.showTooltips && settings.showTooltipWordCount) ||
-        hasAppearanceTextCountConsumer(settings, showsWordCount)
+        hasAppearanceTextCountConsumer(settings, 'words')
     );
 }
 
 export function hasMarkdownCharacterCountConsumer(settings: NotebookNavigatorSettings): boolean {
-    return showsCharacterCount(settings.textCountDisplay) || hasAppearanceTextCountConsumer(settings, showsCharacterCount);
+    return showsCharacterCount(settings.textCountDisplay) || hasAppearanceTextCountConsumer(settings, 'characters');
 }
 
 /** Returns whether a settings update changes which text counts the markdown pipeline must extract. */

--- a/tests/hooks/useListPaneAppearance.test.ts
+++ b/tests/hooks/useListPaneAppearance.test.ts
@@ -49,7 +49,7 @@ describe('resolveListPaneAppearance', () => {
                 showTags: false,
                 showProperties: false,
                 showTaskProgress: false,
-                showTextCount: false
+                textCount: 'none'
             },
             selectionType: ItemType.FOLDER
         });
@@ -76,7 +76,7 @@ describe('resolveListPaneAppearance', () => {
                 showTags: true,
                 showProperties: true,
                 showTaskProgress: true,
-                showTextCount: true
+                textCount: 'words'
             },
             selectionType: ItemType.FOLDER
         });
@@ -89,19 +89,25 @@ describe('resolveListPaneAppearance', () => {
         });
     });
 
-    it('shows the global count type when a selection enables counts', () => {
-        const enabled = resolveListPaneAppearance({
+    it('lets a selection choose a count type independently of the global setting', () => {
+        const inherited = resolveListPaneAppearance({
             settings: createSettings({ textCountDisplay: 'characters' }),
-            appearance: { showTextCount: true },
+            appearance: {},
+            selectionType: ItemType.FOLDER
+        });
+        const words = resolveListPaneAppearance({
+            settings: createSettings({ textCountDisplay: 'characters' }),
+            appearance: { textCount: 'words' },
             selectionType: ItemType.FOLDER
         });
         const disabled = resolveListPaneAppearance({
             settings: createSettings({ textCountDisplay: 'characters' }),
-            appearance: { showTextCount: false },
+            appearance: { textCount: 'none' },
             selectionType: ItemType.FOLDER
         });
 
-        expect(enabled.textCountDisplay).toBe('characters');
+        expect(inherited.textCountDisplay).toBe('characters');
+        expect(words.textCountDisplay).toBe('words');
         expect(disabled.textCountDisplay).toBe('none');
     });
 
@@ -138,6 +144,17 @@ describe('resolveListPaneAppearance', () => {
         });
     });
 
+    it('lets a selection hide preview text without changing preview-based layout sizing', () => {
+        const result = resolveListPaneAppearance({
+            settings: createSettings({ showFilePreview: true, previewRows: 3 }),
+            appearance: { previewRows: 0 },
+            selectionType: ItemType.FOLDER
+        });
+
+        expect(result.previewRows).toBe(3);
+        expect(result.showPreview).toBe(false);
+    });
+
     it('keeps compact tag and property visibility as global style choices', () => {
         const result = resolveListPaneAppearance({
             settings: createSettings({
@@ -164,7 +181,7 @@ describe('resolveListPaneAppearance', () => {
                 textCountPlacement: 'property',
                 showFilePropertiesInCompactMode: false
             }),
-            appearance: { showTextCount: true },
+            appearance: { textCount: 'both' },
             selectionType: ItemType.FOLDER
         });
 
@@ -179,7 +196,7 @@ describe('stored list appearance intent', () => {
             titleRows: 2,
             previewRows: 9,
             showTags: true,
-            showTextCount: false,
+            textCount: 'both',
             showFilePreview: false,
             textCountDisplay: 'both'
         } as ListPaneAppearance);
@@ -188,9 +205,13 @@ describe('stored list appearance intent', () => {
             mode: 'standard',
             titleRows: 2,
             showTags: true,
-            showTextCount: false
+            textCount: 'both'
         });
         expect(hasStoredListPaneAppearanceOverride(stored ?? undefined)).toBe(true);
+    });
+
+    it('retains zero preview rows as an explicit hidden-preview choice', () => {
+        expect(getStoredListPaneAppearanceFields({ previewRows: 0 })).toEqual({ previewRows: 0 });
     });
 
     it('treats toggles stored with different values as different overrides', () => {
@@ -208,7 +229,7 @@ describe('stored list appearance intent', () => {
 describe('appearance map snapshots', () => {
     it('preserves map identity when an unrelated settings update leaves appearances unchanged', () => {
         const current = {
-            Writing: { mode: 'standard', showTextCount: true }
+            Writing: { mode: 'standard', textCount: 'words' }
         } satisfies Record<string, ListPaneAppearance>;
         const initialSnapshot = snapshotListPaneAppearanceMap(current);
         const nextSnapshot = snapshotListPaneAppearanceMap(current, initialSnapshot);
@@ -220,15 +241,15 @@ describe('appearance map snapshots', () => {
 
     it('publishes a new immutable snapshot after an in-place appearance mutation', () => {
         const current = {
-            Writing: { mode: 'standard', showTextCount: true }
+            Writing: { mode: 'standard', textCount: 'words' }
         } satisfies Record<string, ListPaneAppearance>;
         const initialSnapshot = snapshotListPaneAppearanceMap(current);
 
-        current.Writing.showTextCount = false;
+        current.Writing.textCount = 'characters';
         const nextSnapshot = snapshotListPaneAppearanceMap(current, initialSnapshot);
 
         expect(nextSnapshot).not.toBe(initialSnapshot);
-        expect(nextSnapshot.Writing.showTextCount).toBe(false);
-        expect(initialSnapshot.Writing.showTextCount).toBe(true);
+        expect(nextSnapshot.Writing.textCount).toBe('characters');
+        expect(initialSnapshot.Writing.textCount).toBe('words');
     });
 });

--- a/tests/services/MarkdownPipelineWordCount.test.ts
+++ b/tests/services/MarkdownPipelineWordCount.test.ts
@@ -100,11 +100,18 @@ describe('Markdown pipeline appearance relevance', () => {
             textCountDisplay: 'none',
             showTooltips: false,
             showTooltipWordCount: false,
-            folderAppearances: { Writing: { mode: 'compact', showTextCount: true } }
+            folderAppearances: { Writing: { mode: 'compact', textCount: 'words' } }
+        });
+        const charactersEnabled = createSettings({
+            textCountDisplay: 'none',
+            showTooltips: false,
+            showTooltipWordCount: false,
+            folderAppearances: { Writing: { mode: 'compact', textCount: 'characters' } }
         });
 
         expect(haveMarkdownCountConsumersChanged(disabled, visualChange)).toBe(false);
         expect(haveMarkdownCountConsumersChanged(visualChange, countsEnabled)).toBe(true);
+        expect(haveMarkdownCountConsumersChanged(countsEnabled, charactersEnabled)).toBe(true);
         expect(haveMarkdownCountConsumersChanged(countsEnabled, visualChange)).toBe(true);
     });
 });
@@ -390,7 +397,7 @@ describe('MarkdownPipelineContentProvider word count', () => {
         const context = createApp();
         const settings = createSettings({
             textCountDisplay: 'none',
-            folderAppearances: { Writing: { showTextCount: true } }
+            folderAppearances: { Writing: { textCount: 'words' } }
         });
         const provider = new TestMarkdownPipelineContentProvider(context.app);
         const file = createFile('Writing/Draft.md');
@@ -401,6 +408,23 @@ describe('MarkdownPipelineContentProvider word count', () => {
         expect(result.update?.wordCount).toBe(3);
         expect(result.update?.characterCountWithSpaces).toBeUndefined();
         expect(result.update?.characterCountWithoutSpaces).toBeUndefined();
+    });
+
+    it('counts characters when a list appearance selects them while the global setting is off', async () => {
+        const context = createApp();
+        const settings = createSettings({
+            textCountDisplay: 'none',
+            folderAppearances: { Writing: { textCount: 'characters' } }
+        });
+        const provider = new TestMarkdownPipelineContentProvider(context.app);
+        const file = createFile('Writing/Draft.md');
+
+        setMarkdownContent(context, file, 'Three draft words');
+        const result = await provider.runProcessFile(file, null, settings);
+
+        expect(result.update?.wordCount).toBeUndefined();
+        expect(result.update?.characterCountWithSpaces).toBe(17);
+        expect(result.update?.characterCountWithoutSpaces).toBe(15);
     });
 
     it('counts words for sort-activated custom group headers when file counts are hidden', async () => {

--- a/tests/services/PluginSettingsController.test.ts
+++ b/tests/services/PluginSettingsController.test.ts
@@ -329,7 +329,7 @@ describe('PluginSettingsController.loadSettings', () => {
                         previewRows: 4,
                         showTags: true,
                         showProperties: false,
-                        showTextCount: true,
+                        textCount: 'characters',
                         showFilePreview: false,
                         textCountDisplay: 'characters',
                         groupBy: 'folder',
@@ -338,9 +338,9 @@ describe('PluginSettingsController.loadSettings', () => {
                     Invalid: {
                         mode: 'dense',
                         titleRows: 9,
-                        previewRows: 0,
+                        previewRows: -1,
                         showTags: 'yes',
-                        showTextCount: 'on'
+                        textCount: 'on'
                     }
                 }
             })),
@@ -357,9 +357,47 @@ describe('PluginSettingsController.loadSettings', () => {
                 previewRows: 4,
                 showTags: true,
                 showProperties: false,
-                showTextCount: true,
+                textCount: 'characters',
                 groupBy: 'folder'
             }
+        });
+    });
+
+    it('stores appearance values matching global settings as inheritance', async () => {
+        const saveData = vi.fn().mockResolvedValue(undefined);
+        const controller = new PluginSettingsController({
+            keys: STORAGE_KEYS,
+            loadData: vi.fn(async () => ({
+                textCountDisplay: 'none',
+                folderAppearances: {
+                    Inbox: { mode: 'compact', titleRows: 1, previewRows: 2, textCount: 'none' },
+                    Writing: { titleRows: 3, previewRows: 0, textCount: 'words' }
+                }
+            })),
+            saveData,
+            mirrorUXPreferences: vi.fn()
+        });
+
+        await controller.loadSettings();
+
+        expect(controller.settings.folderAppearances).toEqual({
+            Inbox: { mode: 'compact' },
+            Writing: { titleRows: 3, previewRows: 0, textCount: 'words' }
+        });
+
+        saveData.mockClear();
+        controller.settings.fileNameRows = 3;
+        controller.settings.textCountDisplay = 'words';
+        await controller.saveSettings();
+
+        expect(controller.settings.folderAppearances).toEqual({
+            Inbox: { mode: 'compact' },
+            Writing: { previewRows: 0 }
+        });
+        const savedSettings = saveData.mock.calls[0][0] as Record<string, unknown>;
+        expect(savedSettings['folderAppearances']).toEqual({
+            Inbox: { mode: 'compact' },
+            Writing: { previewRows: 0 }
         });
     });
 });


### PR DESCRIPTION
Adds per-location preview and text count choices and keeps inherited appearance values aligned with the global settings.